### PR TITLE
add a new parameter for transifex organization slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ These scripts are written for and tested on GitHub, Travis-CI and Transifex.
  - Deploy plugin releases on QGIS official plugin repository
  - Publish plugin in Github releases, option to deploy a custom repository
  - Easily integrated in Travis-CI
- - Completely handle translations with Transifex: create the project and the languages, pull and push translations 
+ - Completely handle translations with Transifex:
+    - create the project and the languages
+    - pull and push translations
+    - all TS/QM files can be managed on the CI, the `i18n` folder can be omitted from the Git repository
    
 # Command line
 
@@ -99,6 +102,8 @@ In `.qgis-plugin-ci`, you should at least provide the following configuration:
 * plugin_path
 
 You can find a template `.qgis-plugin-ci` in this repository.
+You can read the docstring of the file `qgispluginci/parameters.py`
+to know parameters which are available in the file.
 
 ## QRC and UI files
 

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -22,7 +22,6 @@ class Parameters:
     project_slug: str
         The project slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).
         Not required when running on Travis since deduced from `$TRAVIS_REPO_SLUG`environment variable.
-        Otherwise, defaults to
 
     transifex_coordinator: str
         The username of the coordinator in Transifex.
@@ -30,7 +29,11 @@ class Parameters:
 
     transifex_organization: str
         The organization name in Transifex
-        Defaults to: `organization`
+        Defaults to: the GitHub organization slug
+
+    transifex_project_slug: str
+        The project slug on Transifex, which can be different from the one on GitHub.
+        Defaults to: the project slug
 
     transifex_resource: str
         The resource name in transifex
@@ -39,6 +42,9 @@ class Parameters:
     translation_source_language:
         The source language for translations.
         Defaults to: 'en'
+
+    translation_languages:
+        List of languages.
 
     create_date: datetime.date
         The date of creation of the plugin.
@@ -66,6 +72,7 @@ class Parameters:
         self.transifex_organization = definition.get('transifex_organization', self.github_organization_slug)
         self.translation_source_language = definition.get('translation_source_language', 'en')
         self.translation_languages = definition.get('translation_languages', {})
+        self.transifex_project_slug = definition.get('transifex_project_slug', self.project_slug)
         self.transifex_resource = definition.get('transifex_resource', self.project_slug)
         self.create_date = datetime.datetime.strptime(str(definition.get('create_date', datetime.date.today())), '%Y-%m-%d')
         self.lrelease_path = definition.get('lrelease_path', 'lrelease')

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -31,13 +31,13 @@ class Parameters:
         The organization name in Transifex
         Defaults to: the GitHub organization slug
 
-    transifex_project_slug: str
-        The project slug on Transifex, which can be different from the one on GitHub.
-        Defaults to: the project slug
+    transifex_project: str
+        The project on Transifex, which can be different from the one on GitHub.
+        Defaults to: the project_slug
 
     transifex_resource: str
         The resource name in transifex
-        Defaults to: the project slug
+        Defaults to: the project_slug
 
     translation_source_language:
         The source language for translations.
@@ -72,7 +72,7 @@ class Parameters:
         self.transifex_organization = definition.get('transifex_organization', self.github_organization_slug)
         self.translation_source_language = definition.get('translation_source_language', 'en')
         self.translation_languages = definition.get('translation_languages', {})
-        self.transifex_project_slug = definition.get('transifex_project_slug', self.project_slug)
+        self.transifex_project = definition.get('transifex_project', self.project_slug)
         self.transifex_resource = definition.get('transifex_resource', self.project_slug)
         self.create_date = datetime.datetime.strptime(str(definition.get('create_date', datetime.date.today())), '%Y-%m-%d')
         self.lrelease_path = definition.get('lrelease_path', 'lrelease')

--- a/qgispluginci/translation.py
+++ b/qgispluginci/translation.py
@@ -7,7 +7,7 @@ from qgispluginci.exceptions import TranslationFailed, TransifexNoResource, Tran
 from qgispluginci.utils import touch_file
 
 
-class Translation():
+class Translation:
     def __init__(self, parameters: Parameters,
                  transifex_token: str,
                  create_project: bool = True):
@@ -27,29 +27,30 @@ class Translation():
         self._t = Transifex(transifex_token, parameters.transifex_organization, i18n_type='QT')
         assert self._t.ping()
         self.ts_file = '{dir}/i18n/{res}_{lan}.ts'.format(dir=self.parameters.plugin_path,
-                                                          res=self.parameters.project_slug,
+                                                          res=self.parameters.transifex_resource,
                                                           lan=self.parameters.translation_source_language)
 
-        if self._t.project_exists(parameters.project_slug):
+        if self._t.project_exists(parameters.transifex_project_slug):
             print('Project {o}/{p} exists on Transifex'.format(o=self.parameters.transifex_organization,
-                                                               p=self.parameters.project_slug))
+                                                               p=self.parameters.transifex_project_slug))
         elif create_project:
             print('project does not exists on Transifex, creating one as {o}/{p}'.format(o=self.parameters.transifex_organization,
-                                                                                         p=self.parameters.project_slug))
-            self._t.create_project(slug=parameters.project_slug,
+                                                                                         p=self.parameters.transifex_project_slug))
+            self._t.create_project(slug=self.parameters.transifex_project_slug,
                                 repository_url=self.parameters.repository_url,
                                 source_language_code=parameters.translation_source_language)
             self.update_strings()
-            print('creating resource in {o}/{p} with {f}'.format(o=self.parameters.transifex_organization,
-                                                                 p=self.parameters.project_slug,
+            print('creating resource in {o}/{p}/{r} with {f}'.format(o=self.parameters.transifex_organization,
+                                                                 p=self.parameters.transifex_project_slug,
+                                                                 r=self.parameters.transifex_resource,
                                                                  f=self.ts_file))
-            self._t.create_resource(project_slug=self.parameters.project_slug,
+            self._t.create_resource(project_slug=self.parameters.transifex_project_slug,
                                  path_to_file=self.ts_file,
-                                 resource_slug=self.parameters.project_slug)
+                                 resource_slug=self.parameters.transifex_resource)
             print('OK')
         else:
-            raise TranslationFailed('Project {o}/{p} does notexists on Transifex'.format(
-                o=self.parameters.transifex_organization, p=self.parameters.project_slug))
+            raise TranslationFailed('Project {o}/{p} does not exists on Transifex'.format(
+                o=self.parameters.transifex_organization, p=self.parameters.transifex_project_slug))
 
     def update_strings(self):
         """
@@ -66,7 +67,7 @@ class Translation():
         if output.returncode != 0:
             raise TranslationFailed(output.stderr)
         else:
-            print('Successfuly run pylupdate5: {}'.format(output.stdout))
+            print('Successfully run pylupdate5: {}'.format(output.stdout))
 
     def compile_strings(self):
         """
@@ -79,7 +80,7 @@ class Translation():
         if output.returncode != 0:
             raise TranslationFailed(output.stderr)
         else:
-            print('Successfuly run lrelease: {}'.format(output.stdout))
+            print('Successfully run lrelease: {}'.format(output.stdout))
 
     def pull(self):
         """
@@ -87,7 +88,7 @@ class Translation():
         """
         resource = self.__get_resource()
         existing_langs = self._t.list_languages(
-            project_slug=self.parameters.project_slug, resource_slug=resource['slug']
+            project_slug=self.parameters.transifex_project_slug, resource_slug=resource['slug']
         )
         existing_langs.remove(self.parameters.translation_source_language)
         print('{c} languages found for resource ''{s}'' ({langs})'.format(
@@ -96,28 +97,28 @@ class Translation():
         for lang in self.parameters.translation_languages:
             if lang not in existing_langs:
                 print('creating missing language: {}'.format(lang))
-                self._t.create_language(self.parameters.project_slug, lang, [self.parameters.transifex_coordinator])
+                self._t.create_language(self.parameters.transifex_project_slug, lang, [self.parameters.transifex_coordinator])
                 existing_langs.append(lang)
         for lang in existing_langs:
             ts_file = '{dir}/i18n/{res}_{lan}.ts'.format(dir=self.parameters.plugin_path,
-                                                         res=self.parameters.project_slug,
+                                                         res=self.parameters.transifex_project_slug,
                                                          lan=lang)
             print('downloading translation file: {}'.format(ts_file))
-            self._t.get_translation(self.parameters.project_slug, resource['slug'], lang, ts_file)
+            self._t.get_translation(self.parameters.transifex_project_slug, resource['slug'], lang, ts_file)
 
     def push(self):
         resource = self.__get_resource()
-        print('pushing resource: {} with file {}'.format(resource['slug'], self.ts_file))
+        print('pushing resource: {} with file {}'.format(self.parameters.transifex_resource, self.ts_file))
         result = self._t.update_source_translation(
-            project_slug=self.parameters.project_slug,
+            project_slug=self.parameters.transifex_project_slug,
             resource_slug=resource['slug'],
             path_to_file=self.ts_file)
         print('done: {}'.format(result))
 
     def __get_resource(self) -> dict:
-        resources = self._t.list_resources(self.parameters.project_slug)
+        resources = self._t.list_resources(self.parameters.transifex_resource)
         if len(resources) == 0:
-            raise TransifexNoResource("project '{}' has no resource on Transifex".format(self.parameters.project_slug))
+            raise TransifexNoResource("project '{}' has no resource on Transifex".format(self.parameters.transifex_project_slug))
         if len(resources) > 1:
             for resource in resources:
                 if resource['name'] == self.parameters.transifex_resource:
@@ -125,5 +126,5 @@ class Translation():
             raise TransifexManyResources("project '{p}' has several resources on Transifex "
                                          "and none is named as the project slug."
                                          "Specify one in the parameters with transifex_resource"
-                                         .format(p=self.parameters.project_slug))
+                                         .format(p=self.parameters.transifex_project_slug))
         return resources[0]

--- a/qgispluginci/translation.py
+++ b/qgispluginci/translation.py
@@ -30,27 +30,27 @@ class Translation:
                                                           res=self.parameters.transifex_resource,
                                                           lan=self.parameters.translation_source_language)
 
-        if self._t.project_exists(parameters.transifex_project_slug):
+        if self._t.project_exists(parameters.transifex_project):
             print('Project {o}/{p} exists on Transifex'.format(o=self.parameters.transifex_organization,
-                                                               p=self.parameters.transifex_project_slug))
+                                                               p=self.parameters.transifex_project))
         elif create_project:
             print('project does not exists on Transifex, creating one as {o}/{p}'.format(o=self.parameters.transifex_organization,
-                                                                                         p=self.parameters.transifex_project_slug))
-            self._t.create_project(slug=self.parameters.transifex_project_slug,
+                                                                                         p=self.parameters.transifex_project))
+            self._t.create_project(slug=self.parameters.transifex_project,
                                 repository_url=self.parameters.repository_url,
                                 source_language_code=parameters.translation_source_language)
             self.update_strings()
             print('creating resource in {o}/{p}/{r} with {f}'.format(o=self.parameters.transifex_organization,
-                                                                 p=self.parameters.transifex_project_slug,
+                                                                 p=self.parameters.transifex_project,
                                                                  r=self.parameters.transifex_resource,
                                                                  f=self.ts_file))
-            self._t.create_resource(project_slug=self.parameters.transifex_project_slug,
+            self._t.create_resource(project_slug=self.parameters.transifex_project,
                                  path_to_file=self.ts_file,
                                  resource_slug=self.parameters.transifex_resource)
             print('OK')
         else:
             raise TranslationFailed('Project {o}/{p} does not exists on Transifex'.format(
-                o=self.parameters.transifex_organization, p=self.parameters.transifex_project_slug))
+                o=self.parameters.transifex_organization, p=self.parameters.transifex_project))
 
     def update_strings(self):
         """
@@ -88,7 +88,7 @@ class Translation:
         """
         resource = self.__get_resource()
         existing_langs = self._t.list_languages(
-            project_slug=self.parameters.transifex_project_slug, resource_slug=resource['slug']
+            project_slug=self.parameters.transifex_project, resource_slug=resource['slug']
         )
         existing_langs.remove(self.parameters.translation_source_language)
         print('{c} languages found for resource ''{s}'' ({langs})'.format(
@@ -97,20 +97,20 @@ class Translation:
         for lang in self.parameters.translation_languages:
             if lang not in existing_langs:
                 print('creating missing language: {}'.format(lang))
-                self._t.create_language(self.parameters.transifex_project_slug, lang, [self.parameters.transifex_coordinator])
+                self._t.create_language(self.parameters.transifex_project, lang, [self.parameters.transifex_coordinator])
                 existing_langs.append(lang)
         for lang in existing_langs:
             ts_file = '{dir}/i18n/{res}_{lan}.ts'.format(dir=self.parameters.plugin_path,
-                                                         res=self.parameters.transifex_project_slug,
+                                                         res=self.parameters.transifex_project,
                                                          lan=lang)
             print('downloading translation file: {}'.format(ts_file))
-            self._t.get_translation(self.parameters.transifex_project_slug, resource['slug'], lang, ts_file)
+            self._t.get_translation(self.parameters.transifex_project, resource['slug'], lang, ts_file)
 
     def push(self):
         resource = self.__get_resource()
         print('pushing resource: {} with file {}'.format(self.parameters.transifex_resource, self.ts_file))
         result = self._t.update_source_translation(
-            project_slug=self.parameters.transifex_project_slug,
+            project_slug=self.parameters.transifex_project,
             resource_slug=resource['slug'],
             path_to_file=self.ts_file)
         print('done: {}'.format(result))
@@ -118,7 +118,7 @@ class Translation:
     def __get_resource(self) -> dict:
         resources = self._t.list_resources(self.parameters.transifex_resource)
         if len(resources) == 0:
-            raise TransifexNoResource("project '{}' has no resource on Transifex".format(self.parameters.transifex_project_slug))
+            raise TransifexNoResource("project '{}' has no resource on Transifex".format(self.parameters.transifex_project))
         if len(resources) > 1:
             for resource in resources:
                 if resource['name'] == self.parameters.transifex_resource:
@@ -126,5 +126,5 @@ class Translation:
             raise TransifexManyResources("project '{p}' has several resources on Transifex "
                                          "and none is named as the project slug."
                                          "Specify one in the parameters with transifex_resource"
-                                         .format(p=self.parameters.transifex_project_slug))
+                                         .format(p=self.parameters.transifex_project))
         return resources[0]


### PR DESCRIPTION
Our slugs are:
* on GitHub : https://github.com/3liz
* on Transifex : https://www.transifex.com/3liz-1 :( 

So I'm introducing a transifex organisation slug.

When I started this, I thought that like in all plugins, TS files would be commited on the repository. Then I noticed that everything is managed on the CI, so I tried to improve a little bit from what I understand.

It still not easy to understand what is created automatically and what is not by this tool, but I'm making my way ;-)
Thanks for this tool.