### PR TITLE
add changelog in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+### 0.1.2 - 23/07/2020
+
+* Add a CHANGELOG.md file for testing
+
+### 0.1.1 - 22/07/2020
+
+* Previous version
+
+### 0.1.0 - 21/07/2020
+
+* Very old version
+
+###

--- a/README.md
+++ b/README.md
@@ -10,8 +10,29 @@ These scripts are written for and tested on GitHub, Travis-CI, github workflows 
     - create the project and the languages
     - pull and push translations
     - all TS/QM files can be managed on the CI, the `i18n` folder can be omitted from the Git repository
+ - `changelog` section in the metadata.txt can be populated if the CHANGELOG.md is present
    
 # Command line
+
+```commandline
+usage: qgis-plugin-ci [-h] [-v]
+                      {package,changelog,release,pull-translation,push-translation}
+                      ...
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         print the version and exit
+
+commands:
+  qgis-plugin-ci command
+
+  {package,changelog,release,pull-translation,push-translation}
+    package             creates an archive of the plugin
+    changelog           gets the changelog content
+    release             release the plugin
+    pull-translation    pull translations from Transifex
+    push-translation    update strings and push translations
+```
 
 ## Package
 
@@ -98,6 +119,21 @@ usage: qgis-plugin-ci push-translation [-h] transifex_token
 
 positional arguments:
   transifex_token  The Transifex API token
+
+optional arguments:
+  -h, --help       show this help message and exit
+```
+
+## Changelog
+
+By default, the changelog command will work with a file formatted like [this changelog.md file](./CHANGELOG.md).
+If your format is different, you must use a different `changelog_regexp` expression to parse it in your settings.
+
+```commandline
+usage: qgis-plugin-ci changelog [-h] release_version
+
+positional arguments:
+  release_version  The version to be released
 
 optional arguments:
   -h, --help       show this help message and exit
@@ -291,6 +327,7 @@ These plugins are using this tool, with different configurations as examples:
   * released on custom repo as GitHub release
 * https://github.com/3liz/lizmap-plugin
   * using a `setup.cfg` file
+  * metadata populated automatically from CHANGELOG.md file
   * GitHub release created automatically from Travis
   * released on official repository
   * translations are committed from Travis to the repository after the release process

--- a/qgis_plugin_ci_testing/metadata.txt
+++ b/qgis_plugin_ci_testing/metadata.txt
@@ -7,6 +7,7 @@ about=Downloading would be useless
 version=dev
 author=Denis Rouzaud
 email=denis@opengis.ch
+changelog=changelog
 
 # Tags are comma separated with spaces allowed
 tags=

--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -1,0 +1,53 @@
+"""Changelog parser.
+
+Following nearly https://keepachangelog.com/en/1.0.0/
+"""
+
+import re
+
+from os.path import isfile
+
+
+class ChangelogParser:
+
+    @staticmethod
+    def has_changelog():
+        return isfile('CHANGELOG.md')
+
+    def __init__(self, regexp):
+        self.regexp = regexp
+
+    def _parse(self):
+        if not self.has_changelog():
+            return ''
+
+        f = open('CHANGELOG.md', "r")
+        content = f.read()
+        f.close()
+        return re.findall(self.regexp, content, flags=re.MULTILINE | re.DOTALL)
+
+    def last_items(self, count):
+        """Content to add in the metadata.txt.
+
+        :param count: Maximum number of tags to include in the file.
+        """
+        changelog_content = self._parse()
+        if not changelog_content:
+            return ''
+
+        count = int(count)
+        output = '\n'
+        for version, date, items in changelog_content[0:count]:
+            output += ' Version {}:\n'.format(version)
+            for item in items.split('\n'):
+                if item:
+                    output += ' {}\n'.format(item)
+            output += '\n'
+        return output
+
+    def content(self, tag):
+        """Content to add in a release according to a tag."""
+        changelog_content = self._parse()
+        for version, date, items in changelog_content:
+            if version == tag:
+                return items.strip()

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -46,6 +46,18 @@ class Parameters:
     translation_languages:
         List of languages.
 
+    changelog_include:
+        If the changelog must be added when releasing a version AND if there is a CHANGELOG.md file
+        Defaults to True
+
+    changelog_number_of_entries:
+        Number of changelog entries to add in the metdata.txt
+        Defaults to 3
+
+    changelog_regexp:
+        Regular expression used to parse the CHANGELOG.md
+        Defaults to https://regex101.com/r/PXoYSs/3 following nearly the https://keepachangelog.com/en/1.0.0/
+
     create_date: datetime.date
         The date of creation of the plugin.
         The would be used in the custom repository XML.
@@ -77,6 +89,13 @@ class Parameters:
         self.create_date = datetime.datetime.strptime(str(definition.get('create_date', datetime.date.today())), '%Y-%m-%d')
         self.lrelease_path = definition.get('lrelease_path', 'lrelease')
         self.pylupdate5_path = definition.get('pylupdate5_path', 'pylupdate5')
+        changelog_include = definition.get('changelog_include', True)
+        if isinstance(changelog_include, str):
+            self.changelog_include = changelog_include.lower() in ['true', '1', 't', 'y']
+        else:
+            self.changelog_include = changelog_include
+        self.changelog_number_of_entries = definition.get('changelog_number_of_entries', 3)
+        self.changelog_regexp = definition.get('changelog_regexp', r"(?<=##)\s*\[*(\d*\d\.\d*\d\.\d*\d)\]*\s-\s([\d\-/]{10})(.*?)(?=##)")
 
         # read from metadata
         self.author = self.__get_from_metadata('author', '')

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -5,6 +5,7 @@ import configparser
 import os
 import yaml
 
+from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import ConfigurationNotFound
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
@@ -32,6 +33,10 @@ def main():
         help='If omitted, uncommitted changes are not allowed before packaging. If specified and some changes are '
              'detected, a hard reset on a stash create will be used to revert changes made by qgis-plugin-ci.'
     )
+
+    # changelog
+    changelog_parser = subparsers.add_parser('changelog', help='gets the changelog content')
+    changelog_parser.add_argument('release_version', help='The version to be released')
 
     # release
     release_parser = subparsers.add_parser('release', help='release the plugin')
@@ -117,6 +122,17 @@ def main():
             osgeo_password=args.osgeo_password,
             allow_uncommitted_changes=args.allow_uncommitted_changes,
         )
+
+    # CHANGELOG
+    elif args.command == 'changelog':
+        try:
+            c = ChangelogParser(parameters.changelog_regexp)
+            content = c.content(args.release_version)
+            if content:
+                print(content)
+        except Exception:
+            # Better to be safe
+            pass
 
     # TRANSLATION PULL
     elif args.command == 'pull-translation':

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+
+import unittest
+
+from qgispluginci.changelog import ChangelogParser
+
+
+class TestChangelog(unittest.TestCase):
+
+    def test_changelog_parser(self):
+        """ Test we can parse a changelog with a regex. """
+        self.assertTrue(ChangelogParser.has_changelog())
+        parser = ChangelogParser(r"(?<=##)\s*\[*(\d*\d\.\d*\d\.\d*\d)\]*\s-\s([\d\-/]{10})(.*?)(?=##)")
+        self.assertIsNone(parser.content('0.0.0'), '')
+        self.assertEqual(parser.content('0.1.2'), '* Add a CHANGELOG.md file for testing')
+
+        expected = '\n Version 0.1.2:\n * Add a CHANGELOG.md file for testing\n\n'
+        self.assertEqual(parser.last_items(1), expected)
+
+        expected = ("""
+ Version 0.1.2:
+ * Add a CHANGELOG.md file for testing
+
+ Version 0.1.1:
+ * Previous version
+
+ Version 0.1.0:
+ * Very old version
+
+""")
+        self.assertEqual(parser.last_items(3), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -7,6 +7,7 @@ import filecmp
 import urllib.request
 from tempfile import mkstemp
 from github import Github, GithubException
+from zipfile import ZipFile
 
 from pytransifex.exceptions import PyTransifexException
 
@@ -16,7 +17,7 @@ from qgispluginci.translation import Translation
 from qgispluginci.exceptions import GithubReleaseNotFound
 from qgispluginci.utils import replace_in_file
 
-# if change, also update on .travis.yml
+# if change, also update on .travis.yml and CHANGELOG.md
 RELEASE_VERSION_TEST = '0.1.2'
 
 
@@ -96,6 +97,16 @@ class TestRelease(unittest.TestCase):
                 break
         self.assertTrue(found, 'asset not found')
 
+    def test_release_changelog(self):
+        """ Test about the changelog in the metadata.txt. """
+        expected = b'changelog=\n Version 0.1.2:\n * Add a CHANGELOG.md file for testing\n'
+
+        # Include a changelog
+        release(self.parameters, RELEASE_VERSION_TEST)
+        archive_name = self.parameters.archive_name(RELEASE_VERSION_TEST)
+        with ZipFile(archive_name, 'r') as zip_file:
+            data = zip_file.read('qgis_plugin_ci_testing/metadata.txt')
+            self.assertGreater(data.find(expected), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It looks fragile but it works well for us :)
It allow us to populate the `changelog` section in the `metadata.txt` file like:

```
version=0.3.6
changelog=
 Version 0.3.6:
 * Send project to clone - parameters: add password and remove clone connection
 * ...

 Version 0.3.5:
 * Bidirectionnal synchronization - Make sure to truncate clone audit log, even for rejected actions
 * ...

 Version 0.3.4:
 * Database synchro - Correctly update central audit.logged_actions for discarded UPDATEs
 * ...
```

Example of changelog.md file : https://github.com/3liz/qgis-lizsync-plugin/blob/master/CHANGELOG.md