### PR TITLE
allow creation of plugins.xml in the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ These scripts are written for and tested on GitHub, Travis-CI, github workflows 
 
 ## Package
 
+This command is not specific to the hosting platform (GitLab, GitHub…)
+
 ```commandline
-usage: qgis-plugin-ci package [-h] [--transifex-token TRANSIFEX_TOKEN]
+usage: qgis-plugin-ci package [-h]
+                              [--transifex-token TRANSIFEX_TOKEN]
+                              [--plugin-repo-url PLUGIN_REPO_URL]
                               [--allow-uncommitted-changes]
                               release_version
 
@@ -28,6 +32,8 @@ optional arguments:
   --transifex-token TRANSIFEX_TOKEN
                         The Transifex API token. If specified translations
                         will be pulled and compiled.
+  --plugin-repo-url PLUGIN_REPO_URL
+                        If specified, a XML repository file will be created in the current directory, the zip URL will use this parameter.
   --allow-uncommitted-changes
                         If omitted, uncommitted changes are not allowed before
                         packaging. If specified and some changes are detected,
@@ -36,6 +42,8 @@ optional arguments:
 ```
 
 ## Release
+
+This command is specific for plugins hosted on GitHub.
 
 ```commandline
 usage: qgis-plugin-ci release [-h] [--transifex-token TRANSIFEX_TOKEN]

--- a/qgispluginci/plugins.xml.template
+++ b/qgispluginci/plugins.xml.template
@@ -8,7 +8,7 @@
         <file_name>__PLUGINZIP__</file_name>
         <icon>__ICON__</icon>
         <author_name>__AUTHOR__</author_name>
-        <download_url>https://github.com/__ORG__/__REPO__/releases/download/__RELEASE_TAG__/__PLUGINZIP__</download_url>
+        <download_url>__DOWNLOAD_URL__</download_url>
         <uploaded_by>__OSGEO_USERNAME__</uploaded_by>
         <create_date>__CREATE_DATE__</create_date>
         <update_date>__RELEASE_DATE__</update_date>

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -34,7 +34,9 @@ def release(parameters: Parameters,
             transifex_token: str = None,
             osgeo_username: str = None,
             osgeo_password: str = None,
-            allow_uncommitted_changes: bool = False):
+            allow_uncommitted_changes: bool = False,
+            plugin_repo_url: str = None,
+            ):
     """
     
     Parameters
@@ -50,6 +52,8 @@ def release(parameters: Parameters,
         The Github token
     upload_plugin_repo_github
         If true, a custom repo will be created as a release asset on Github and could later be used in QGIS as a custom plugin repository.
+    plugin_repo_url
+        If set, this URL will be used to create the ZIP URL in the XML file
     transifex_token
         The Transifex token
     osgeo_username
@@ -112,6 +116,17 @@ def release(parameters: Parameters,
                 github_token=github_token,
                 asset_name='plugins.xml'
             )
+
+    if plugin_repo_url:
+        xml_repo = create_plugin_repo(
+            parameters=parameters,
+            release_version=release_version,
+            release_tag=release_tag,
+            archive=archive_name,
+            osgeo_username=osgeo_username,
+            plugin_repo_url=plugin_repo_url,
+        )
+        print('Local XML repo file created : {}'.format(xml_repo))
 
     if osgeo_username is not None:
         assert osgeo_password is not None
@@ -303,12 +318,12 @@ def create_plugin_repo(
         release_version: str,
         release_tag: str,
         archive: str,
-        osgeo_username
+        osgeo_username,
+        plugin_repo_url=None,
 ) -> str:
     """
     Creates the plugin repo as an XML file
     """
-    _, xml_repo = mkstemp(suffix='.xml')
     replace_dict = {
         '__RELEASE_VERSION__': release_version,
         '__RELEASE_TAG__': release_tag or release_version,
@@ -330,6 +345,21 @@ def create_plugin_repo(
         '__HOMEPAGE__': parameters.homepage,
         '__REPO_URL__': parameters.repository_url
     }
+    if not plugin_repo_url:
+        download_url = 'https://github.com/{org}/{repo}/releases/download/{tag}/{pluginzip}'.format(
+            org=replace_dict['__ORG__'],
+            repo=replace_dict['__REPO__'],
+            tag=replace_dict['__RELEASE_TAG__'],
+            pluginzip=replace_dict['__PLUGINZIP__'],
+        )
+        _, xml_repo = mkstemp(suffix='.xml')
+    else:
+        download_url = '{url}{pluginzip}'.format(
+            url=plugin_repo_url,
+            pluginzip=replace_dict['__PLUGINZIP__'],
+        )
+        xml_repo = './plugins.xml'
+    replace_dict['__DOWNLOAD_URL__'] = download_url
     with importlib_resources.path('qgispluginci', 'plugins.xml.template') as xml_template:
         configure_file(xml_template, xml_repo, replace_dict)
     return xml_repo

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -25,6 +25,9 @@ def main():
         '--transifex-token', help='The Transifex API token. If specified translations will be pulled and compiled.'
     )
     package_parser.add_argument(
+        '--plugin-repo-url', help='If specified, a XML repository file will be created in the current directory, the zip URL will use this parameter.'
+    )
+    package_parser.add_argument(
         '--allow-uncommitted-changes', action='store_true',
         help='If omitted, uncommitted changes are not allowed before packaging. If specified and some changes are '
              'detected, a hard reset on a stash create will be used to revert changes made by qgis-plugin-ci.'
@@ -98,7 +101,8 @@ def main():
             parameters,
             release_version=args.release_version,
             transifex_token=args.transifex_token,
-            allow_uncommitted_changes=args.allow_uncommitted_changes
+            allow_uncommitted_changes=args.allow_uncommitted_changes,
+            plugin_repo_url=args.plugin_repo_url,
         )
 
     # RELEASE


### PR DESCRIPTION
We have plugins hosted on GitLab. The `release` command is specific to GitHub.

With this PR, we can create the plugins.xml in the current directory, by specifying the URL which will be used for downloading the zip.

I will have conflicts with other opened PR.