### PR TITLE
Use real plugin name instead of hardcoded plugin name in translation function

### DIFF
--- a/qgispluginci/translation.py
+++ b/qgispluginci/translation.py
@@ -58,9 +58,10 @@ class Translation:
         Update TS files from plugin source strings
         """
         source_files = []
+        relative_path = './{plugin_path}'.format(plugin_path=self.parameters.plugin_path)
         for ext in ('py', 'ui'):
             for file in glob.glob('{dir}/**/*.{ext}'.format(dir=self.parameters.plugin_path, ext=ext), recursive=True):
-                source_files.append(str(Path(file).relative_to('./qgis_plugin_ci_testing')))
+                source_files.append(str(Path(file).relative_to(relative_path)))
         
         touch_file(self.ts_file)
 
@@ -69,7 +70,7 @@ class Translation:
         with open(project_file, 'w') as f:
             assert f.write('CODECFORTR = UTF-8\n')
             assert f.write('SOURCES = {}\n'.format(' '.join(source_files)))
-            assert f.write('TRANSLATIONS = {}\n'.format(Path(self.ts_file).relative_to('./qgis_plugin_ci_testing')))
+            assert f.write('TRANSLATIONS = {}\n'.format(Path(self.ts_file).relative_to(relative_path)))
             f.flush()
             f.close()
 


### PR DESCRIPTION
It should fix #20 
It seems the plugin name `qgis_plugin_ci_testing` was hardcoded.

Thanks @3nids for running tests on the opengis repo.