### PR TITLE
Use underscore instead of hyphen for plugin name #22

### DIFF
--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -13,7 +13,7 @@ class Parameters:
     ----------
     plugin_path: str
         The directory of the source code in the repository.
-        Defaults to: `slugify(plugin_name, separator='_')`
+        Defaults to: `slugify(plugin_name)`
 
     github_organization_slug: str
         The organization slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).
@@ -117,9 +117,9 @@ class Parameters:
         Returns the archive file name
         """
         # zipname: use dot before version number
-        # and not dash since it's causing issues
+        # and not dash since it's causing issues #22
         return '{zipname}{experimental}.{release_version}.zip'.format(
-            zipname=self.plugin_slug,
+            zipname=self.plugin_slug.replace('-', '_'),
             experimental='-experimental' if experimental else '',
             release_version=release_version
         )

--- a/test/plugins.xml.expected
+++ b/test/plugins.xml.expected
@@ -5,10 +5,10 @@
         <version>0.1.2</version>
         <qgis_minimum_version>3.2</qgis_minimum_version>
         <homepage>https://github.com/opengisch/qgis-plugin-ci</homepage>
-        <file_name>qgis-plugin-ci-testing.0.1.2.zip</file_name>
+        <file_name>qgis_plugin_ci-testing.0.1.2.zip</file_name>
         <icon>icons/opengisch.png</icon>
         <author_name>Denis Rouzaud</author_name>
-        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis-plugin-ci-testing.0.1.2.zip</download_url>
+        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_ci-testing.0.1.2.zip</download_url>
         <uploaded_by>Denis Rouzaud</uploaded_by>
         <create_date>1985-07-21</create_date>
         <update_date>__TODAY__</update_date>

--- a/test/plugins.xml.expected
+++ b/test/plugins.xml.expected
@@ -5,10 +5,10 @@
         <version>0.1.2</version>
         <qgis_minimum_version>3.2</qgis_minimum_version>
         <homepage>https://github.com/opengisch/qgis-plugin-ci</homepage>
-        <file_name>qgis_plugin_ci-testing.0.1.2.zip</file_name>
+        <file_name>qgis_plugin_ci_testing.0.1.2.zip</file_name>
         <icon>icons/opengisch.png</icon>
         <author_name>Denis Rouzaud</author_name>
-        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_ci-testing.0.1.2.zip</download_url>
+        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_ci_testing.0.1.2.zip</download_url>
         <uploaded_by>Denis Rouzaud</uploaded_by>
         <create_date>1985-07-21</create_date>
         <update_date>__TODAY__</update_date>


### PR DESCRIPTION
I can't really run tests locally, let's check Travis.

Fix #22 