### PR TITLE
Update the changelog regular expression if there is a v prefix in the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ### 0.1.2 - 23/07/2020
 
+* Tag without "v" prefix
 * Add a CHANGELOG.md file for testing
 
-### 0.1.1 - 22/07/2020
+### v0.1.1 - 22/07/2020
 
+* Tag with a "v" prefix to check the regular expression
 * Previous version
 
 ### 0.1.0 - 21/07/2020

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -6,6 +6,8 @@ from slugify import slugify
 import datetime
 import warnings
 
+CHANGELOG_REGEXP = r"(?<=##)\s*\[*(v?\d*\d\.\d*\d\.\d*\d)\]*\s-\s([\d\-/]{10})(.*?)(?=##)"
+
 
 class Parameters:
     """
@@ -56,7 +58,7 @@ class Parameters:
 
     changelog_regexp:
         Regular expression used to parse the CHANGELOG.md
-        Defaults to https://regex101.com/r/PXoYSs/3 following nearly the https://keepachangelog.com/en/1.0.0/
+        Defaults to https://regex101.com/r/PXoYSs/4 following nearly the https://keepachangelog.com/en/1.0.0/
 
     create_date: datetime.date
         The date of creation of the plugin.
@@ -95,7 +97,7 @@ class Parameters:
         else:
             self.changelog_include = changelog_include
         self.changelog_number_of_entries = definition.get('changelog_number_of_entries', 3)
-        self.changelog_regexp = definition.get('changelog_regexp', r"(?<=##)\s*\[*(\d*\d\.\d*\d\.\d*\d)\]*\s-\s([\d\-/]{10})(.*?)(?=##)")
+        self.changelog_regexp = definition.get('changelog_regexp', CHANGELOG_REGEXP)
 
         # read from metadata
         self.author = self.__get_from_metadata('author', '')

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -3,6 +3,7 @@
 import unittest
 
 from qgispluginci.changelog import ChangelogParser
+from qgispluginci.parameters import CHANGELOG_REGEXP
 
 
 class TestChangelog(unittest.TestCase):
@@ -10,18 +11,20 @@ class TestChangelog(unittest.TestCase):
     def test_changelog_parser(self):
         """ Test we can parse a changelog with a regex. """
         self.assertTrue(ChangelogParser.has_changelog())
-        parser = ChangelogParser(r"(?<=##)\s*\[*(\d*\d\.\d*\d\.\d*\d)\]*\s-\s([\d\-/]{10})(.*?)(?=##)")
+        parser = ChangelogParser(CHANGELOG_REGEXP)
         self.assertIsNone(parser.content('0.0.0'), '')
-        self.assertEqual(parser.content('0.1.2'), '* Add a CHANGELOG.md file for testing')
+        self.assertEqual(parser.content('0.1.2'), '* Tag without "v" prefix\n* Add a CHANGELOG.md file for testing')
 
-        expected = '\n Version 0.1.2:\n * Add a CHANGELOG.md file for testing\n\n'
+        expected = '\n Version 0.1.2:\n * Tag without "v" prefix\n * Add a CHANGELOG.md file for testing\n\n'
         self.assertEqual(parser.last_items(1), expected)
 
         expected = ("""
  Version 0.1.2:
+ * Tag without "v" prefix
  * Add a CHANGELOG.md file for testing
 
- Version 0.1.1:
+ Version v0.1.1:
+ * Tag with a "v" prefix to check the regular expression
  * Previous version
 
  Version 0.1.0:

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -99,7 +99,7 @@ class TestRelease(unittest.TestCase):
 
     def test_release_changelog(self):
         """ Test about the changelog in the metadata.txt. """
-        expected = b'changelog=\n Version 0.1.2:\n * Add a CHANGELOG.md file for testing\n'
+        expected = b'changelog=\n Version 0.1.2:\n * Tag without "v" prefix\n * Add a CHANGELOG.md file for testing'
 
         # Include a changelog
         release(self.parameters, RELEASE_VERSION_TEST)


### PR DESCRIPTION
Update the changelog regular expression if there is a v prefix in the tag

The user can still customize the regular expression by using the `changelog_regexp` parameter : 
https://github.com/opengisch/qgis-plugin-ci/blob/master/qgispluginci/parameters.py#L57