### PR TITLE
Changelog: add latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,15 @@ optional arguments:
 ## Changelog
 
 By default, the changelog command will work with a file formatted like [this changelog.md file](./CHANGELOG.md).
+
 If your format is different, you must use a different `changelog_regexp` expression to parse it in your settings.
 
 ```commandline
 usage: qgis-plugin-ci changelog [-h] release_version
 
 positional arguments:
-  release_version  The version to be released
+  release_version  The version to be released. If nothing is speficied, the latest 
+                   version specified into the changelog is used.
 
 optional arguments:
   -h, --help       show this help message and exit

--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -21,9 +21,9 @@ class ChangelogParser:
         if not self.has_changelog():
             return ''
 
-        f = open('CHANGELOG.md', "r")
-        content = f.read()
-        f.close()
+        with open('CHANGELOG.md', "r") as f: 
+            content = f.read()
+
         return re.findall(self.regexp, content, flags=re.MULTILINE | re.DOTALL)
 
     def last_items(self, count):

--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -14,7 +14,7 @@ class ChangelogParser:
     def has_changelog():
         return isfile('CHANGELOG.md')
 
-    def __init__(self, regexp):
+    def __init__(self, regexp: str):
         self.regexp = regexp
 
     def _parse(self):
@@ -26,7 +26,7 @@ class ChangelogParser:
 
         return re.findall(self.regexp, content, flags=re.MULTILINE | re.DOTALL)
 
-    def last_items(self, count):
+    def last_items(self, count: int) -> str:
         """Content to add in the metadata.txt.
 
         :param count: Maximum number of tags to include in the file.
@@ -45,9 +45,12 @@ class ChangelogParser:
             output += '\n'
         return output
 
-    def content(self, tag):
+    def content(self, tag: str) -> str:
         """Content to add in a release according to a tag."""
         changelog_content = self._parse()
+        if tag == "latest":
+            for version, date, items in changelog_content[:1]:
+                return items.strip()
         for version, date, items in changelog_content:
             if version == tag:
                 return items.strip()

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -40,7 +40,11 @@ def main():
 
     # changelog
     changelog_parser = subparsers.add_parser('changelog', help='gets the changelog content')
-    changelog_parser.add_argument('release_version', help='The version to be released')
+    changelog_parser.add_argument('release_version',
+                                  help='The version to be released. If nothing is speficied, \
+                                      the latest version specified into the changelog is used.',
+                                  default="latest"
+                                  )
 
     # release
     release_parser = subparsers.add_parser('release', help='release the plugin')

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -14,7 +14,7 @@ from qgispluginci.parameters import Parameters
 
 def main():
     # create the top-level parser
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-v", "--version", help="print the version and exit", action='store_true')
 
     subparsers = parser.add_subparsers(title='commands', description='qgis-plugin-ci command', dest='command')

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -1,4 +1,12 @@
-#! /usr/bin/env python
+#! python3  # noqa E265
+
+"""
+    Usage from the repo root folder:
+
+    .. code-block:: python
+        # for whole test
+        python -m unittest test.test_changelog
+"""
 
 import unittest
 
@@ -7,18 +15,20 @@ from qgispluginci.parameters import CHANGELOG_REGEXP
 
 
 class TestChangelog(unittest.TestCase):
-
     def test_changelog_parser(self):
         """ Test we can parse a changelog with a regex. """
         self.assertTrue(ChangelogParser.has_changelog())
         parser = ChangelogParser(CHANGELOG_REGEXP)
-        self.assertIsNone(parser.content('0.0.0'), '')
-        self.assertEqual(parser.content('0.1.2'), '* Tag without "v" prefix\n* Add a CHANGELOG.md file for testing')
+        self.assertIsNone(parser.content("0.0.0"), "")
+        self.assertEqual(
+            parser.content("0.1.2"),
+            '* Tag without "v" prefix\n* Add a CHANGELOG.md file for testing',
+        )
 
         expected = '\n Version 0.1.2:\n * Tag without "v" prefix\n * Add a CHANGELOG.md file for testing\n\n'
         self.assertEqual(parser.last_items(1), expected)
 
-        expected = ("""
+        expected = """
  Version 0.1.2:
  * Tag without "v" prefix
  * Add a CHANGELOG.md file for testing
@@ -30,9 +40,19 @@ class TestChangelog(unittest.TestCase):
  Version 0.1.0:
  * Very old version
 
-""")
+"""
         self.assertEqual(parser.last_items(3), expected)
 
+    def test_changelog_latest(self):
+        """Test against the latest special option value. \
+        See: https://github.com/opengisch/qgis-plugin-ci/pull/33
+        """
+        self.assertTrue(ChangelogParser.has_changelog())
+        parser = ChangelogParser(CHANGELOG_REGEXP)
+        expected_latest = '* Tag without "v" prefix\n* Add a CHANGELOG.md file for testing'
+        print(parser.content("latest"))
+        self.assertEqual(expected_latest, parser.content("latest"))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a shortcut to automatically return the latest version item from the changelog using the `latest` keyword.

Considering this changelog:

```markdown
# CHANGELOG

### 0.1.2 - 23/07/2020

* Tag without "v" prefix
* Add a CHANGELOG.md file for testing

### v0.1.1 - 22/07/2020

* Tag with a "v" prefix to check the regular expression
* Previous version

### 0.1.0 - 21/07/2020

* Very old version

###
```

The command: `qgis-plugin-ci changelog latest` would return:

```bash
* Tag without "v" prefix
* Add a CHANGELOG.md file for testing
```