### PR TITLE
Disable some tests when not running on CI because of missing tokens

### DIFF
--- a/test/test_release.py
+++ b/test/test_release.py
@@ -13,6 +13,7 @@ from zipfile import ZipFile
 import yaml
 from github import Github, GithubException
 from pytransifex.exceptions import PyTransifexException
+from utils import can_skip_test
 
 # Project
 from qgispluginci.changelog import ChangelogParser
@@ -69,8 +70,8 @@ class TestRelease(unittest.TestCase):
     def test_release(self):
         release(self.parameters, RELEASE_VERSION_TEST)
 
+    @unittest.skipIf(can_skip_test(), "Missing transifex_token")
     def test_release_with_transifex(self):
-        assert self.transifex_token is not None
         Translation(self.parameters, transifex_token=self.transifex_token)
         release(
             self.parameters, RELEASE_VERSION_TEST, transifex_token=self.transifex_token
@@ -94,6 +95,7 @@ class TestRelease(unittest.TestCase):
         with self.assertWarnsRegex(Warning, DASH_WARNING):
             Parameters.archive_name("my-plugin", "0.0.0")
 
+    @unittest.skipIf(can_skip_test(), "Missing github_token")
     def test_release_upload_github(self):
         release(
             self.parameters,

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -7,6 +7,7 @@ import unittest
 # 3rd party
 import yaml
 from pytransifex.exceptions import PyTransifexException
+from utils import can_skip_test
 
 # project
 from qgispluginci.parameters import Parameters
@@ -31,15 +32,18 @@ class TestTranslation(unittest.TestCase):
         except PyTransifexException:
             pass
 
+    @unittest.skipIf(can_skip_test(), "Missing transifex_token")
     def test_creation(self):
         self.t = Translation(self.parameters, transifex_token=self.transifex_token)
         self.tearDown()
         self.t = Translation(self.parameters, transifex_token=self.transifex_token)
 
+    @unittest.skipIf(can_skip_test(), "Missing transifex_token")
     def test_pull(self):
         self.t.pull()
         self.t.compile_strings()
 
+    @unittest.skipIf(can_skip_test(), "Missing transifex_token")
     def test_push(self):
         self.t.update_strings()
         self.t.push()

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,16 @@
+import os
+
+
+def can_skip_test():
+    """ Check when a test can run. """
+    is_ci = os.getenv("CI") == "true"
+    is_main_repo = os.getenv("GITHUB_REPOSITORY") == "opengisch/qgis-plugin-ci"
+    if is_ci and is_main_repo:
+        # Always run the test on CI
+        return False
+
+    if not os.getenv("transifex_token") or not os.getenv("github_token"):
+        # On local, the token must be set
+        return True
+
+    return False


### PR DESCRIPTION
Easier for debugging on local, to run tests.