### PR TITLE
Add release "next" version command

### DIFF
--- a/docs/usage/cli_changelog.md
+++ b/docs/usage/cli_changelog.md
@@ -17,6 +17,8 @@ or
 changelog_path=subfolder/CHANGELOG.md
 ```
 
+It also provides two keywords `next` and `latest` instead of using a version number when creating a zip.
+
 ## Command help
 
 ```bash
@@ -39,6 +41,14 @@ The `CHANGELOG.md` file must follow the convention [Keep A Changelog](https://ke
 - Extract the `CHANGELOG.md` content and copy it into the `changelog` section within plugin `metadata.txt`
 - Extract the `n` latest versions from `CHANGELOG.md` into `metadata.txt`
 - Get the latest version release note
+- When packaging or releasing, you can use these keywords :
+  - `latest` will make a package of the latest tag described in the changelog file.
+  - `next` will make a package of the possible smallest higher tag :
+    - `3.4.0` -> `3.4.1-alpha`
+    - `3.4.0-alpha` -> `3.4.1-alpha.1`
+    - `3.4.0-alpha1` -> `3.4.1-alpha2`
+
+Be careful when you use the `next` command. It is designed to make a package which is not based on a specific version (on CI mainly). You should be careful with the tag you are creating if you have some packages delivered as well with the `next` command otherwise QGIS Plugin manager might not warn users about possible new release.
 
 ## Examples
 

--- a/qgispluginci/version_note.py
+++ b/qgispluginci/version_note.py
@@ -29,3 +29,36 @@ class VersionNote(NamedTuple):
             return f"{self.major}.{self.minor}.{self.patch}-{self.prerelease}"
         else:
             return f"{self.major}.{self.minor}.{self.patch}"
+
+    def increment_pre_release(self) -> str:
+        """Increment the pre-release string."""
+        items = self.prerelease.split(".")
+
+        numbers = "".join([i for i in self.prerelease if i.isdigit()])
+
+        if len(items) == 1:
+            if numbers:
+                return f"{self.prerelease[0:-len(numbers)]}{int(numbers) + 1}"
+            else:
+                return f"{self.prerelease}.1"
+
+        return f"{items[0]}.{int(numbers) + 1}"
+
+    def next_version(self) -> NamedTuple:
+        """Increment the pre-release string or the patch."""
+        # "pre" is not supported by QGIS
+        # https://github.com/qgis/QGIS/blob/master/python/pyplugin_installer/version_compare.py
+        if not self.prerelease:
+            return VersionNote(
+                major=self.major,
+                minor=self.minor,
+                patch=str(int(self.patch) + 1),
+                prerelease="alpha",
+            )
+
+        return VersionNote(
+            major=self.major,
+            minor=self.minor,
+            patch=self.patch,
+            prerelease=self.increment_pre_release(),
+        )

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -19,7 +19,7 @@ from pytransifex.exceptions import PyTransifexException
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import GithubReleaseNotFound
 from qgispluginci.parameters import DASH_WARNING, Parameters
-from qgispluginci.release import release
+from qgispluginci.release import check_release_keywords, release
 from qgispluginci.translation import Translation
 from qgispluginci.utils import replace_in_file
 
@@ -189,6 +189,23 @@ class TestRelease(unittest.TestCase):
 
         # Commit sha1 not in the metadata.txt
         self.assertEqual(0, len(re.findall(r"commitSha1=\d+", str(data))))
+
+    def test_release_latest_next(self):
+        """Test releasing the latest and next versions."""
+        keywords = ("next", "latest")
+        for keyword in keywords:
+            with self.subTest(i=keyword):
+                release(self.parameters, keyword)
+                archive_name = self.parameters.archive_name(
+                    self.parameters.plugin_path, check_release_keywords(keyword)
+                )
+
+                with ZipFile(archive_name, "r") as zip_file:
+                    data = zip_file.read("qgis_plugin_CI_testing/metadata.txt")
+
+                # Version is the one in __about__.py
+                self.assertEqual(data.find(b"version=latest"), -1)
+                self.assertEqual(data.find(b"version=dev"), -1)
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,6 +49,22 @@ class TestUtils(unittest.TestCase):
         self.assertIsNone(version.prerelease)
         self.assertFalse(version.is_prerelease)
 
+    def test_next_version(self):
+        """Test to guess the next version."""
+        self.assertEqual(parse_tag("10.1.0").next_version().version, "10.1.1-alpha")
+        self.assertEqual(
+            parse_tag("10.1.0-beta").next_version().version, "10.1.0-beta.1"
+        )
+        self.assertEqual(
+            parse_tag("10.1.0-beta1").next_version().version, "10.1.0-beta2"
+        )
+        self.assertEqual(
+            parse_tag("10.1.0-beta.2").next_version().version, "10.1.0-beta.3"
+        )
+        self.assertEqual(
+            parse_tag("10.1.0-rc.10").next_version().version, "10.1.0-rc.11"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This would be convenient on CI, to make a package when it's not based on a "tag", but rather on a commit.
The version must always be lower in the metadata.txt otherwise QGIS Plugin Manager won't notify the user for a new version.

Fix #34

