### PR TITLE
Quick fix for having a version when using pip install with editable mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
+import os
 import sys
 
 from setuptools import setup
 
 python_min_version = (3, 7)
 
-VERSION = "__VERSION__"
+if os.getenv("CI") == "true":
+    # Version is set by the CI with a tag
+    VERSION = "__VERSION__"
+else:
+    # When using pip install -e /local/path/to/this/repo
+    VERSION = "0.0.0"
 
 if sys.version_info < python_min_version:
     sys.exit(


### PR DESCRIPTION
While waiting for #42 this is a quick hack when using `pip install -e /path/to/this/repo`.
https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables