### PR TITLE
Remove the changelog_regexp parameter, and make the changelog command standalone

### DIFF
--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -73,10 +73,8 @@ class ChangelogParser:
 
     def __init__(
         self,
-        regexp: str = CHANGELOG_REGEXP,
         parent_folder: Union[Path, str] = Path("."),
     ):
-        self.regexp = regexp
         self.has_changelog(parent_folder=parent_folder)
 
     def _parse(self):
@@ -87,7 +85,7 @@ class ChangelogParser:
             content = f.read()
 
         return re.findall(
-            pattern=self.regexp, string=content, flags=re.MULTILINE | re.DOTALL
+            pattern=CHANGELOG_REGEXP, string=content, flags=re.MULTILINE | re.DOTALL
         )
 
     def last_items(self, count: int) -> str:

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -18,9 +18,6 @@ import warnings
 # 3rd party
 from slugify import slugify
 
-# project
-from qgispluginci.changelog import CHANGELOG_REGEXP
-
 # ############################################################################
 # ########## Globals #############
 # ################################
@@ -83,10 +80,6 @@ class Parameters:
         Number of changelog entries to add in the metdata.txt
         Defaults to 3
 
-    changelog_regexp:
-        Regular expression used to parse the CHANGELOG.md
-        Defaults to https://regex101.com/r/PXoYSs/4 following nearly the https://keepachangelog.com/en/1.0.0/
-
     create_date: datetime.date
         The date of creation of the plugin.
         The would be used in the custom repository XML.
@@ -145,7 +138,6 @@ class Parameters:
         self.changelog_number_of_entries = definition.get(
             "changelog_number_of_entries", 3
         )
-        self.changelog_regexp = definition.get("changelog_regexp", CHANGELOG_REGEXP)
 
         # read from metadata
         self.author = self.__get_from_metadata("author", "")

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -65,7 +65,7 @@ def create_archive(
 
     # changelog
     if parameters.changelog_include:
-        parser = ChangelogParser(regexp=parameters.changelog_regexp)
+        parser = ChangelogParser()
         if parser.has_changelog():
             try:
                 content = parser.last_items(

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -131,6 +131,21 @@ def main():
 
     exit_val = 0
 
+    # CHANGELOG
+    if args.command == "changelog":
+        # The changelog command can be used outside of a QGIS plugin
+        # We don't need the configuration file
+        try:
+            c = ChangelogParser()
+            content = c.content(args.release_version)
+            if content:
+                print(content)
+        except Exception:
+            # Better to be safe
+            pass
+
+        return exit_val
+
     if os.path.isfile(".qgis-plugin-ci"):
         arg_dict = yaml.safe_load(open(".qgis-plugin-ci"))
     else:
@@ -168,17 +183,6 @@ def main():
             allow_uncommitted_changes=args.allow_uncommitted_changes,
             disable_submodule_update=args.disable_submodule_update,
         )
-
-    # CHANGELOG
-    elif args.command == "changelog":
-        try:
-            c = ChangelogParser(regexp=parameters.changelog_regexp)
-            content = c.content(args.release_version)
-            if content:
-                print(content)
-        except Exception:
-            # Better to be safe
-            pass
 
     # TRANSLATION PULL
     elif args.command == "pull-translation":

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -157,7 +157,7 @@ class TestRelease(unittest.TestCase):
         )
 
         # extract last items from changelog
-        parser = ChangelogParser(regexp=parameters.changelog_regexp)
+        parser = ChangelogParser()
         self.assertTrue(parser.has_changelog())
         changelog_lastitems = parser.last_items(
             count=parameters.changelog_number_of_entries


### PR DESCRIPTION
* Remove the parameter `changelog_regexp` : CF discussion https://github.com/opengisch/qgis-plugin-ci/pull/49#discussion_r611516691

Since the merge of #49, existing `changelog_regexp` are already broken anyway.

* It seems I'm the first one to use qgis-plugin-ci **outside** of a QGIS plugin repository :) Just to parse the changelog.md file and fill the GIT release.