### PR TITLE
Fix CHANGELOG not found in certain situation

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -6,8 +6,8 @@ import sys
 import tarfile
 import xmlrpc.client
 import zipfile
-from pathlib import Path
 from glob import glob
+from pathlib import Path
 from tempfile import mkstemp
 
 import git

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -6,6 +6,7 @@ import sys
 import tarfile
 import xmlrpc.client
 import zipfile
+from pathlib import Path
 from glob import glob
 from tempfile import mkstemp
 
@@ -64,7 +65,7 @@ def create_archive(
 
     # changelog
     if parameters.changelog_include:
-        parser = ChangelogParser()
+        parser = ChangelogParser(Path(parameters.plugin_path).resolve().parent)
         if parser.has_changelog():
             try:
                 content = parser.last_items(

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -6,6 +6,8 @@ import os
 
 import yaml
 
+from pathlib import Path
+
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import ConfigurationNotFound
 from qgispluginci.parameters import Parameters
@@ -134,21 +136,6 @@ def main():
 
     exit_val = 0
 
-    # CHANGELOG
-    if args.command == "changelog":
-        # The changelog command can be used outside of a QGIS plugin
-        # We don't need the configuration file
-        try:
-            c = ChangelogParser()
-            content = c.content(args.release_version)
-            if content:
-                print(content)
-        except Exception:
-            # Better to be safe
-            pass
-
-        return exit_val
-
     if os.path.isfile(".qgis-plugin-ci"):
         arg_dict = yaml.safe_load(open(".qgis-plugin-ci"))
     else:
@@ -159,8 +146,22 @@ def main():
                 ".qgis-plugin-ci or setup.cfg with a 'qgis-plugin-ci' section have not been found."
             )
         arg_dict = dict(config.items("qgis-plugin-ci"))
-
     parameters = Parameters(arg_dict)
+
+    # CHANGELOG
+    if args.command == "changelog":
+        # The changelog command can be used outside of a QGIS plugin
+        # We don't need the configuration file
+        try:
+            c = ChangelogParser(Path(parameters.plugin_path).resolve().parent)
+            content = c.content(args.release_version)
+            if content:
+                print(content)
+        except Exception:
+            # Better to be safe
+            pass
+
+        return exit_val
 
     # PACKAGE
     if args.command == "package":

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -3,10 +3,9 @@
 import argparse
 import configparser
 import os
+from pathlib import Path
 
 import yaml
-
-from pathlib import Path
 
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import ConfigurationNotFound


### PR DESCRIPTION
I propose a change for the following situation which raises the following error:

```FileNotFoundError: [Errno 2] No such file or directory: 'CHANGELOG.md'```

I have a project structure like this:

my_project/
├── data/
├── docs/
├── plugin_plugin-name/
│   ├── plugin-name/
│   ├── CHANGELOG.md
│   ├── docs/
│   ├── LICENSE
│   ├── linters/
│   ├── README.md
│   ├── requirements/
│   └── tests/
├── README.md
├── .git/
├── .gitlab-ci.yml
├── .gitignore
└── setup.cfg

 So my `setup.cfg` `[qgis-plugin-ci]` section contains:

```
[qgis-plugin-ci]
plugin_path = plugin_plugin-name/plugin-name
```

When I run `qgis-plugin-ci package latest` in the `my_project` directory I get the error mentioned.

This proposed change fixes this.
