### PR TITLE
Add new parameter "changelog_path" to have a specific file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## Unreleased
 
+* Add the possibility to choose the changelog filepath in the configuration file with `changelog_path`
 * Add some aliases in the command line for some parameters
 * Update the documentation
-* Fix some changelog file not found when used in a sub folder
 
 ## 2.0.1 - 2021-05-11
 

--- a/docs/usage/cli_changelog.md
+++ b/docs/usage/cli_changelog.md
@@ -3,6 +3,20 @@
 Manipulate `CHANGELOG.md` file, extracting relevant information.  
 Used within the [package](cli_package) and [release](cli_release) commands to populate the `metadata.txt` and the GitHub Release description.
 
+By default, the script will look for a file `CHANGELOG.md` in the root folder.
+But you can specify a specific file path with `changelog_path` in the configuration file.
+For instance:
+
+```ini
+changelog_path=CHANGELOG-3.4.md
+```
+
+or
+
+```ini
+changelog_path=subfolder/CHANGELOG.md
+```
+
 ## Command help
 
 ```bash

--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -34,7 +34,9 @@ class ChangelogParser:
     CHANGELOG_FILEPATH: Union[Path, None] = None
 
     @classmethod
-    def has_changelog(cls, parent_folder: Union[Path, str] = Path(".")) -> bool:
+    def has_changelog(
+        cls, parent_folder: Union[Path, str] = Path("."), changelog_path="CHANGELOG.md"
+    ) -> bool:
         """Check if a changelog file exists within the parent folder. If it does, \
         it returns True and the file path is stored as class attribute. If not, it \
         returns False and the class attribute is reset to None.
@@ -42,6 +44,8 @@ class ChangelogParser:
         Args:
             parent_folder (Union[Path, str], optional): parent folder where to look \
                 for a `CHANGELOG.md` file. Defaults to Path(".").
+
+            changelog_path str: Path relative to parent_folder. Defaults to CHANGELOG.md.
 
         Raises:
             FileExistsError: if the parent_folder path doesn't exist
@@ -67,7 +71,7 @@ class ChangelogParser:
             raise TypeError(f"Path is not a folder: {parent_folder.resolve()}")
 
         # build, check and store the changelog path
-        cls.CHANGELOG_FILEPATH = parent_folder / "CHANGELOG.md"
+        cls.CHANGELOG_FILEPATH = parent_folder / changelog_path
         if cls.CHANGELOG_FILEPATH.is_file():
             logger.info(f"Changelog file used: {cls.CHANGELOG_FILEPATH.resolve()}")
 
@@ -76,8 +80,9 @@ class ChangelogParser:
     def __init__(
         self,
         parent_folder: Union[Path, str] = Path("."),
+        changelog_path: str = "CHANGELOG.md",
     ):
-        self.has_changelog(parent_folder=parent_folder)
+        self.has_changelog(parent_folder=parent_folder, changelog_path=changelog_path)
 
     def _parse(self):
         if not self.CHANGELOG_FILEPATH:

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -76,6 +76,9 @@ class Parameters:
         If the changelog must be added when releasing a version AND if there is a CHANGELOG.md file
         Defaults to True
 
+    changelog_path:
+        Path to the CHANGELOG.md relative to the configuration file. Defaults to CHANGELOG.md
+
     changelog_number_of_entries:
         Number of changelog entries to add in the metdata.txt
         Defaults to 3
@@ -95,7 +98,7 @@ class Parameters:
     """
 
     def __init__(self, definition: dict):
-        self.plugin_path = definition["plugin_path"]
+        self.plugin_path = definition.get("plugin_path")
         self.plugin_name = self.__get_from_metadata("name")
         self.plugin_slug = slugify(self.plugin_name)
         self.project_slug = definition.get(
@@ -138,8 +141,13 @@ class Parameters:
         self.changelog_number_of_entries = definition.get(
             "changelog_number_of_entries", 3
         )
+        self.changelog_path = definition.get("changelog_path", "CHANGELOG.md")
 
         # read from metadata
+        if not self.plugin_path:
+            # This tool can be used outside of a QGIS plugin to read a changelog file
+            return
+
         self.author = self.__get_from_metadata("author", "")
         self.description = self.__get_from_metadata("description")
         self.qgis_minimum_version = self.__get_from_metadata("qgisMinimumVersion")
@@ -175,6 +183,9 @@ class Parameters:
         )
 
     def __get_from_metadata(self, key: str, default_value: any = None) -> str:
+        if not self.plugin_path:
+            return ""
+
         metadata_file = "{}/metadata.txt".format(self.plugin_path)
         with open(metadata_file) as f:
             for line in f:

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -65,7 +65,10 @@ def create_archive(
 
     # changelog
     if parameters.changelog_include:
-        parser = ChangelogParser(Path(parameters.plugin_path).resolve().parent)
+        parser = ChangelogParser(
+            parent_folder=Path(parameters.plugin_path).resolve().parent,
+            changelog_path=parameters.changelog_path,
+        )
         if parser.has_changelog():
             try:
                 content = parser.last_items(
@@ -420,7 +423,10 @@ def release(
     """
 
     if release_version == "latest":
-        parser = ChangelogParser()
+        parser = ChangelogParser(
+            parent_folder=Path(parameters.plugin_path).resolve().parent,
+            changelog_path=parameters.changelog_path,
+        )
         release_version = parser.latest_version()
 
     if transifex_token is not None:

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -3,7 +3,6 @@
 import argparse
 import configparser
 import os
-from pathlib import Path
 
 import yaml
 
@@ -149,10 +148,10 @@ def main():
 
     # CHANGELOG
     if args.command == "changelog":
-        # The changelog command can be used outside of a QGIS plugin
-        # We don't need the configuration file
         try:
-            c = ChangelogParser(Path(parameters.plugin_path).resolve().parent)
+            c = ChangelogParser(
+                changelog_path=parameters.changelog_path,
+            )
             content = c.content(args.release_version)
             if content:
                 print(content)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,13 @@ exclude =
     dist,
     # This contains local virtual environments
     .venv*,
+    venv*,
     # do not watch on tests
     tests,
     # do not consider external packages
-    */external/*, ext_libs/*,qgis_pluginCI_testing
+    */external/*,
+    ext_libs/*,
+    qgis_plugin_CI_testing/*
 ignore = E121,E123,E126,E203,E226,E24,E704,W503,W504
 max-complexity = 15
 max-doc-length = 130
@@ -39,3 +42,7 @@ line_length = 88
 multi_line_output = 3
 profile = black
 use_parentheses = True
+skip=
+    qgis_plugin_CI_testing/,
+    .venv,
+    venv,

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -11,12 +11,12 @@
 """
 
 # standard library
+import tempfile
 import unittest
 from pathlib import Path
 
 # project
 from qgispluginci.changelog import ChangelogParser
-from qgispluginci.utils import parse_tag
 from qgispluginci.version_note import VersionNote
 
 # ############################################################################
@@ -119,6 +119,22 @@ class TestChangelog(unittest.TestCase):
 
         self.assertIsInstance(fake_version_content, str)
         self.assertEqual(expected, fake_version_content)
+
+    def test_different_changelog_file(self):
+        """Test against a different changelog filename."""
+        old = Path("test/fixtures/CHANGELOG.md")
+        new_folder = Path(tempfile.mkdtemp())
+        new_path = new_folder / Path("CHANGELOG-branch-X.md")
+        self.assertFalse(new_path.exists())
+
+        new_path.write_text(old.read_text())
+
+        self.assertTrue(
+            ChangelogParser.has_changelog(
+                parent_folder=new_folder,
+                changelog_path=new_path,
+            )
+        )
 
     def test_changelog_last_items(self):
         """Test last items from changelog."""


### PR DESCRIPTION
This PR is fixing a regression in the master branch from @Djedouas https://github.com/opengisch/qgis-plugin-ci/pull/82 (when no configuration file was there)
but also adding a new feature, the user can set a custom path to the changelog file. (different filename or different path)

@Djedouas You would need to use `changelog_path` in the configuration file, is-it OK ?
