### PR TITLE
Fix regression when using the changelog command without a configuration file

### DIFF
--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -135,15 +135,24 @@ def main():
     exit_val = 0
 
     if os.path.isfile(".qgis-plugin-ci"):
+        # We read the .qgis-plugin-ci file
         arg_dict = yaml.safe_load(open(".qgis-plugin-ci"))
     else:
         config = configparser.ConfigParser()
         config.read("setup.cfg")
-        if "qgis-plugin-ci" not in config.sections():
-            raise ConfigurationNotFound(
-                ".qgis-plugin-ci or setup.cfg with a 'qgis-plugin-ci' section have not been found."
-            )
-        arg_dict = dict(config.items("qgis-plugin-ci"))
+        if "qgis-plugin-ci" in config.sections():
+            # We read the setup.cfg file
+            arg_dict = dict(config.items("qgis-plugin-ci"))
+        else:
+            # We don't have either a .qgis-plugin-ci or a setup.cfg
+            if args.command == "changelog":
+                # but for the "changelog" sub command, the config file is not required, we can continue
+                arg_dict = dict()
+            else:
+                raise ConfigurationNotFound(
+                    ".qgis-plugin-ci or setup.cfg with a 'qgis-plugin-ci' section have not been found."
+                )
+
     parameters = Parameters(arg_dict)
 
     # CHANGELOG


### PR DESCRIPTION
Regression in the latest version 2.1.0.

For the `changelog` command, the config file can be used. But it's not required.

I would like to make a tag 2.1.1 ASAP when this is merged.
