### PR TITLE
Add some metadata when packaging in the metadata.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## Unreleased
 
+* Add some metadata in the `metadata.txt` when packaging such as commit number, commit SHA1 and date if these keys are presents
+
 ## 2.2.0 - 2022-03-17
 
-* allow to release a version (1.2.3) which is different from the release tag (v1.2.3) (#120)
+* Allow to release a version (1.2.3) which is different from the release tag (v1.2.3) (#120)
+
+## 2.1.2 - 2022-02-15
+
+* Raise an error if a built resource is present in source and the names conflicts by @3nids
 
 ## 2.1.1 - 2022-01-20
 

--- a/docs/usage/cli_package.md
+++ b/docs/usage/cli_package.md
@@ -28,3 +28,22 @@ optional arguments:
                         If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.
 
 ```
+
+## Additional metadata
+
+When packaging the plugin, some extra metadata information can be added if these keys are present in the `metadata.txt`:
+
+* `commitNumber=` : the commit number in the branch
+* `commitSha1=` : the commit ID
+* `dateTime=` : the date time in UTC format when the packaging is done
+
+* :::{tip}
+These extra parameters are specific to QGIS Plugin CI, so it's strongly recommended storing them below a dedicated section:
+
+```ini
+[tool:qgis-plugin-ci]
+commitNumber=
+commitSha1=
+dateTime=
+```
+:::

--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -39,3 +39,22 @@ optional arguments:
   --osgeo-password OSGEO_PASSWORD
                         The Osgeo password to publish the plugin.
 ```
+
+## Additional metadata
+
+When packaging the plugin, some extra metadata information can be added if these keys are present in the `metadata.txt`:
+
+* `commitNumber=` : the commit number in the branch
+* `commitSha1=` : the commit ID
+* `dateTime=` : the date time in UTC format when the packaging is done
+
+* :::{tip}
+These extra parameters are specific to QGIS Plugin CI, so it's strongly recommended storing them below a dedicated section:
+
+```ini
+[tool:qgis-plugin-ci]
+commitNumber=
+commitSha1=
+dateTime=
+```
+:::

--- a/qgis_plugin_CI_testing/metadata.txt
+++ b/qgis_plugin_CI_testing/metadata.txt
@@ -23,3 +23,6 @@ experimental=True
 
 # change icon...
 icon=icons/opengisch.png
+
+[tool:qgis-plugin-ci]
+commitNumber=

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -106,6 +106,30 @@ def create_archive(
         "version={}".format(release_version),
     )
 
+    # Commit number
+    replace_in_file(
+        f"{parameters.plugin_path}/metadata.txt",
+        r"^commitNumber=.*$",
+        f"commitNumber={len(list(repo.iter_commits()))}",
+    )
+
+    # Git SHA1
+    replace_in_file(
+        f"{parameters.plugin_path}/metadata.txt",
+        r"^commitSha1=.*$",
+        f"commitSha1={repo.head.object.hexsha}",
+    )
+
+    # Date/time in UTC
+    date_time = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    replace_in_file(
+        f"{parameters.plugin_path}/metadata.txt",
+        r"^dateTime=.*$",
+        f"dateTime={date_time}",
+    )
+
     # set the plugin as experimental on a pre-release
     if is_prerelease:
         replace_in_file(

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -7,11 +7,13 @@ import unittest
 # 3rd party
 import yaml
 from pytransifex.exceptions import PyTransifexException
-from utils import can_skip_test
 
 # project
 from qgispluginci.parameters import Parameters
 from qgispluginci.translation import Translation
+
+# Tests
+from .utils import can_skip_test
 
 
 class TestTranslation(unittest.TestCase):


### PR DESCRIPTION
I would like to add some metadata when packaging the plugin such as datetime, commit ID and commit number : 
```ini
commitNumber=812
commitSha1=9259b6d23f31fb1116e9469b2b58c8cf71d7137c
dateTime=2022-03-15T13:11:46Z
```

These are not official in QGIS, but I can make a PR in the documentation to include them in the file https://github.com/qgis/QGIS-Documentation/blob/master/docs/pyqgis_developer_cookbook/plugins/plugins.rst#plugin-metadata
