### PR TITLE
add unix permissions to ZipFile

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -230,7 +230,11 @@ def create_archive(
                 f = tt.extractfile(m)
                 fl = f.read()
                 fn = m.name
-                zf.writestr(fn, fl)
+                # Get permissions and add it to ZipInfo
+                st = os.stat(m.name)
+                info = zipfile.ZipInfo(fn)
+                info.external_attr = (st[0] & 0o777) << 16  # Unix attributes
+                zf.writestr(info, fl)
 
     print("-------")
     print("files in ZIP archive ({}):".format(archive_name))


### PR DESCRIPTION
When extracting .zip archive, file permissions are not available.

It comes from the way we create the file in the .zip archive. We must add the permissions in the `ZipInfo`.

This is what is done in the ZipFile module when creating ZipInfo : https://github.com/python/cpython/blob/b885b8f4be9c74ef1ce7923dbf055c31e7f47735/Lib/zipfile.py#L545