### PR TITLE
Fix regression in 2.4 where zip was not compressed

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -238,6 +238,7 @@ def create_archive(
                 # code : https://github.com/python/cpython/blob/b885b8f4be9c74ef1ce7923dbf055c31e7f47735/Lib/zipfile.py#L545
                 # see https://stackoverflow.com/questions/434641/how-do-i-set-permissions-attributes-on-a-file-in-a-zip-file-using-pythons-zip/53008127#53008127
                 info.external_attr = (st[0] & 0xFFFF) << 16  # Unix attributes
+                info.compress_type = zf.compression
                 zf.writestr(info, fl)
 
     print("-------")


### PR DESCRIPTION
[Commit af9312c4](https://github.com/opengisch/qgis-plugin-ci/commit/af9312c42f5e249994fbc3c7538a2efd3c633cd0) introduced a bug by passing a newly created `ZipInfo` object to `ZipFile.writestr`, implicitly setting each file's compression method to `ZIP_STORED`.

According to [the docs](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.writestr):

> When passing a [ZipInfo](https://docs.python.org/3/library/zipfile.html#zipfile.ZipInfo) instance as the zinfo_or_arcname parameter, the compression method used will be that specified in the compress_type member of the given [ZipInfo](https://docs.python.org/3/library/zipfile.html#zipfile.ZipInfo) instance. By default, the [ZipInfo](https://docs.python.org/3/library/zipfile.html#zipfile.ZipInfo) constructor sets this member to [ZIP_STORED](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_STORED).