### PR TITLE
Feature: add verbosity option and improve log

### DIFF
--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -11,6 +11,7 @@
 # standard library
 import logging
 import re
+import sys
 from pathlib import Path
 from typing import Union
 
@@ -63,19 +64,29 @@ class ChangelogParser:
 
         # check if the folder exists
         if not parent_folder.exists():
-            raise FileExistsError(
-                f"Parent folder doesn't exist: {parent_folder.resolve()}"
+            logger.error(
+                f"Parent folder doesn't exist: {parent_folder.resolve()}",
+                exc_info=FileExistsError(),
             )
+            sys.exit(1)
         # check if path is a folder
         if not parent_folder.is_dir():
-            raise TypeError(f"Path is not a folder: {parent_folder.resolve()}")
+            logger.error(
+                f"Path is not a folder: {parent_folder.resolve()}", exc_info=TypeError()
+            )
+            sys.exit(1)
 
         # build, check and store the changelog path
         cls.CHANGELOG_FILEPATH = parent_folder / changelog_path
         if cls.CHANGELOG_FILEPATH.is_file():
             logger.info(f"Changelog file used: {cls.CHANGELOG_FILEPATH.resolve()}")
-
-        return cls.CHANGELOG_FILEPATH.is_file()
+            return True
+        else:
+            logger.warning(
+                f"Changelog file doesn't exist: {cls.CHANGELOG_FILEPATH.resolve()}"
+            )
+            cls.CHANGELOG_FILEPATH = None
+            return False
 
     def __init__(
         self,

--- a/qgispluginci/changelog.py
+++ b/qgispluginci/changelog.py
@@ -141,6 +141,10 @@ class ChangelogParser:
     def latest_version(self) -> str:
         """Return the latest tag described in the changelog file."""
         latest = self._version_note("latest")
+        logger.debug(
+            "Latest version retrieved from changelog "
+            f"({self.CHANGELOG_FILEPATH.resolve()}): {latest.version}"
+        )
         return latest.version
 
     def content(self, tag: str) -> Union[str, None]:

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 import os
 import re
+import sys
 
 # 3rd party
 from slugify import slugify
@@ -193,7 +194,8 @@ class Parameters:
                 if m:
                     return m.group(1)
         if default_value is None:
-            raise Exception("missing key in metadata: {}".format(key))
+            logger.error(f"Mandatory key is missing in metadata: {key}")
+            sys.exit(1)
         return default_value
 
 

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -13,7 +13,6 @@ import datetime
 import logging
 import os
 import re
-import warnings
 
 # 3rd party
 from slugify import slugify
@@ -158,9 +157,10 @@ class Parameters:
         self.issue_tracker = self.__get_from_metadata("tracker")
         self.homepage = self.__get_from_metadata("homepage", "")
         if self.homepage == "":
-            warnings.warn(
+            logger.warning(
                 "Homepage is not given in the metadata. "
-                "It is a requirement to publish the plugin on the repository"
+                "It is a mandatory information to publish "
+                "the plugin on the QGIS official repository."
             )
         self.repository_url = self.__get_from_metadata("repository")
 
@@ -174,7 +174,7 @@ class Parameters:
         # zipname: use dot before version number
         # and not dash since it's causing issues #22
         if "-" in plugin_name:
-            warnings.warn(DASH_WARNING)
+            logger.warning(DASH_WARNING)
 
         return "{zipname}{experimental}.{release_version}.zip".format(
             zipname=plugin_name,

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -72,7 +72,7 @@ def create_archive(
                 "Stash or commit them or use -c / --allow-uncommitted-changes option."
             )
             logger.error(err_msg)
-            raise UncommitedChanges(err_msg)
+            sys.exit(err_msg)
         else:
             initial_stash = repo.git.stash("create")
 
@@ -93,7 +93,7 @@ def create_archive(
                         r"^changelog=.*$",
                         "changelog={}".format(content),
                     )
-            except Exception as e:
+            except Exception as exc:
                 # Do not fail the release process if something is wrong when parsing the changelog
                 replace_in_file(
                     "{}/metadata.txt".format(parameters.plugin_path),
@@ -101,9 +101,7 @@ def create_archive(
                     "",
                 )
                 logger.error(
-                    "An exception occurred while parsing the changelog file : {}".format(
-                        e
-                    )
+                    f"An exception occurred while parsing the changelog file: {exc}"
                 )
     else:
         # Remove the changelog line
@@ -342,7 +340,9 @@ def release_is_prerelease(
             f"{gh_release.upload_url}"
         )
     except GithubException as exc:
-        raise GithubReleaseNotFound(f"Release {release_tag} not found. Trace: {exc}")
+        err_msg = f"Release {release_tag} not found. Trace: {exc}"
+        logger.error(err_msg)
+        raise GithubReleaseNotFound(err_msg)
     return gh_release.prerelease
 
 

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -268,7 +268,7 @@ def create_archive(
         repo.git.checkout("--", ".")
 
     # print the result
-    print(
+    print(  # noqa: T2
         f"Plugin archive created: {archive_name} "
         f"({convert_octets(Path(archive_name).stat().st_size)})"
     )

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -33,8 +33,14 @@ from qgispluginci.exceptions import (
 )
 from qgispluginci.parameters import Parameters
 from qgispluginci.translation import Translation
-from qgispluginci.utils import configure_file, parse_tag, replace_in_file
+from qgispluginci.utils import (
+    configure_file,
+    convert_octets,
+    parse_tag,
+    replace_in_file,
+)
 
+# GLOBALS
 logger = logging.getLogger(__name__)
 
 
@@ -245,7 +251,7 @@ def create_archive(
                 zf.writestr(info, fl)
 
     logger.debug("-" * 40)
-    logger.debug("files in ZIP archive ({}):".format(archive_name))
+    logger.debug("Files in ZIP archive ({}):".format(archive_name))
     with zipfile.ZipFile(file=archive_name, mode="r") as zf:
         for f in zf.namelist():
             logger.debug(f)
@@ -257,6 +263,12 @@ def create_archive(
         repo.git.reset("HEAD^")
     else:
         repo.git.checkout("--", ".")
+
+    # print the result
+    print(
+        f"Plugin archive created: {archive_name} "
+        f"({convert_octets(Path(archive_name).stat().st_size)})"
+    )
 
 
 def upload_asset_to_github_release(

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -215,12 +215,16 @@ def create_archive(
             with tarfile.open(top_tar_file, mode="r:") as tt:
                 for n in tt.getnames():
                     if n == file:
-                        raise BuiltResourceInSources(
-                            'The file "{}" is present in the sources and its name conflicts with a just built resource. You might want to remove it from the sources or setting export-ignore in .gitattributes config file.'.format(
-                                file
-                            )
+                        err_msg = (
+                            f"The file {file} is present in the sources and its name "
+                            "conflicts with a just built resource. "
+                            "You might want to remove it from the sources or "
+                            "setting export-ignore in .gitattributes config file."
+                        )
+                        logger.error(err_msg, exc_info=BuiltResourceInSources())
+                        sys.exit(1)
             with tarfile.open(top_tar_file, mode="a") as tt:
-                logger.debug("  adding resource: {}".format(file))
+                logger.debug("\tAdding resource: {}".format(file))
                 # https://stackoverflow.com/a/48462950/1548052
                 tt.add(file)
 

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -71,8 +71,8 @@ def create_archive(
                 "You have uncommitted changes. "
                 "Stash or commit them or use -c / --allow-uncommitted-changes option."
             )
-            logger.error(err_msg)
-            sys.exit(err_msg)
+            logger.error(err_msg, exc_info=UncommitedChanges())
+            sys.exit(1)
         else:
             initial_stash = repo.git.stash("create")
 

--- a/qgispluginci/utils.py
+++ b/qgispluginci/utils.py
@@ -1,8 +1,15 @@
+import logging
 import os
 import re
+from math import floor
+from math import log as math_log
+from math import pow
 from typing import Union
 
 from qgispluginci.version_note import VersionNote
+
+# GLOBALS
+logger = logging.getLogger(__name__)
 
 
 def replace_in_file(file_path: str, pattern, new: str, encoding: str = "utf8"):
@@ -20,6 +27,31 @@ def configure_file(source_file: str, dest_file: str, replace: dict):
         content = re.sub(pattern, new, content, flags=re.M)
     with open(dest_file, "w", encoding="utf-8") as f:
         f.write(content)
+
+
+def convert_octets(octets: int) -> str:
+    """Convert a mount of octets in readable size.
+
+    :param int octets: mount of octets to convert
+
+    :Example:
+
+    .. code-block:: python
+
+        >>> convert_octets(1024)
+        "1ko"
+    """
+    # check zero
+    if octets == 0:
+        return "0 octet"
+
+    # conversion
+    size_name = ("octets", "Ko", "Mo", "Go", "To", "Po")
+    i = int(floor(math_log(octets, 1024)))
+    p = pow(1024, i)
+    s = round(octets / p, 2)
+
+    return "%s %s" % (s, size_name[i])
 
 
 def touch_file(path, update_time: bool = False, create_dir: bool = True):

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,6 +6,7 @@ black
 flake8>=3.8,<4.1
 flake8-builtins>=1.5,<1.6
 flake8-isort>=4.0,<4.3
+flake8-print>=5,<5.1
 pre-commit>=2.10,<2.21
 
 # for testing

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -2,11 +2,12 @@
 
 import argparse
 import configparser
+import logging
 import os
 
 import yaml
 
-from qgispluginci.__about__ import __version__
+from qgispluginci.__about__ import __title_clean__, __version__
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import ConfigurationNotFound
 from qgispluginci.parameters import Parameters
@@ -20,8 +21,17 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
+    # Optional verbosity counter (eg. -v, -vv, -vvv, etc.)
     parser.add_argument(
         "-v",
+        "--verbose",
+        action="count",
+        default=1,
+        dest="verbosity",
+        help="Verbosity level: None = WARNING, -v = INFO, -vv = DEBUG",
+    )
+
+    parser.add_argument(
         "--version",
         action="version",
         version=__version__,
@@ -126,6 +136,21 @@ def main():
     push_tr_parser.add_argument("transifex_token", help="The Transifex API token")
 
     args = parser.parse_args()
+
+    # set log level depending on verbosity argument
+    args.verbosity = 40 - (10 * args.verbosity) if args.verbosity > 0 else 0
+    logging.basicConfig(
+        level=args.verbosity,
+        format="%(asctime)s||%(levelname)s||%(module)s||%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    console = logging.StreamHandler()
+    console.setLevel(args.verbosity)
+
+    # add the handler to the root logger
+    logger = logging.getLogger(__title_clean__)
+    logger.debug(f"Log level set: {logging}")
 
     # if no command is passed, print the help and exit
     if not args.command:

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -189,10 +189,9 @@ def main():
             )
             content = c.content(args.release_version)
             if content:
-                print(content)
-        except Exception:
-            # Better to be safe
-            pass
+                print(content)  # noqa: T2
+        except Exception as exc:
+            logger.error("Something went wrong reading the changelog.", exc_info=exc)
 
         return exit_val
 

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -42,12 +42,12 @@ class TestChangelog(unittest.TestCase):
         self.assertIsInstance(ChangelogParser.CHANGELOG_FILEPATH, Path)
 
         # with a path to a file, must raise a type error
-        with self.assertRaises(TypeError):
+        with self.assertRaises(SystemExit):
             ChangelogParser.has_changelog(parent_folder=Path(__file__))
         self.assertIsNone(ChangelogParser.CHANGELOG_FILEPATH, None)
 
         # with a path to a folder which doesn't exist, must raise a file exists error
-        with self.assertRaises(FileExistsError):
+        with self.assertRaises(SystemExit):
             ChangelogParser.has_changelog(parent_folder=Path("imaginary_path"))
 
     def test_changelog_content(self):

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -96,7 +96,7 @@ class TestRelease(unittest.TestCase):
             "My_Plugin.0.0.0.zip", Parameters.archive_name("My_Plugin", "0.0.0", False)
         )
 
-        with self.assertWarnsRegex(Warning, DASH_WARNING):
+        with self.assertWarns(Warning, DASH_WARNING):
             Parameters.archive_name("my-plugin", "0.0.0")
 
     @unittest.skipIf(can_skip_test(), "Missing github_token")

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -96,8 +96,14 @@ class TestRelease(unittest.TestCase):
             "My_Plugin.0.0.0.zip", Parameters.archive_name("My_Plugin", "0.0.0", False)
         )
 
-        with self.assertWarns(Warning, DASH_WARNING):
+        with self.assertLogs(
+            logger="qgispluginci.parameters", level="WARNING"
+        ) as captured:
             Parameters.archive_name("my-plugin", "0.0.0")
+        self.assertEqual(
+            len(captured.records), 1
+        )  # check that there is only one log message
+        self.assertEqual(captured.records[0].getMessage(), DASH_WARNING)
 
     @unittest.skipIf(can_skip_test(), "Missing github_token")
     def test_release_upload_github(self):


### PR DESCRIPTION
:information_source: this PR supersedes the #155  

## Context

Recently, we faced an issue with the log length using qgis-plugin-ci on GitLab CI/CD:

```log
Job's log exceeded limit of 4194304 bytes.
Job execution will continue but no more output will be collected.
```

See this job: https://gitlab.com/Oslandia/qgis/ign-geotuileur/-/jobs/3056269109

But I've been thinking for a long time that we should reduce the amount of information returned to the terminal or let the end-user pick.

## Proposed 'log policy'

> Meant to be added to contributing guidelines.

- `print` to systematically display information to the CLI end-user and which doesn't require some log filter or format. And mark the statement with `# noqa: T2` to avoid flake8 alerts. Example: `Plugin archive created: qtribu.0.15.0-beta2.zip (Size: 731.37 Ko)`
- `logger.error` for blocking issues or interrupted process. If the case is predictable and predicted, do not raise brutal exception to avoid hard readable trace in terminal. Example:

    ```python
    logger.error(err_msg, exc_info=UncommitedChanges())
    sys.exit(1)
    ```

    ```sh
    2022-09-22 14:47:25||ERROR||release||You have uncommitted changes. Stash or commit them or use -c / --allow-uncommitted-changes option.
    qgispluginci.exceptions.UncommitedChanges
    ```

- `logger.warning` for annoying or imperfect but not blocking situations . Example: `2022-09-22 14:45:01||WARNING||parameters||Homepage is not given in the metadata. It is a mandatory information to publish the plugin on the QGIS official repository.`
- `logger.info` for normal message during the process.
- `logger.debug` for detailed message during specific steps. example: list of zipped files, etc.

## Changes

**STILL IN PROGRESS**

- add a verbosity option `-v` with an incremental count 

   ```sh
   # by default, log nothing except print statement = WARNING
   qgis-plugin-ci package latest
   # -v = INFO
   qgis-plugin-ci -v package latest
   # -vv = DEBUG
   qgis-plugin-ci -vv package latest
   ```

- add a setting into the `setup.cfg` to customize log format. Default: `%(asctime)s||%(levelname)s||%(module)s||%(message)s` - OPTION STILL NOT IMPLEMENTED
- remove option alias `-v` from the `version` option to avoid conflict
- improve some exception handling: mainly add `Trace: {exc}` and use f-string instead of format as recommended
- add some volontary print statements (typically to conclude each successful command)
- add [flake8-print](https://github.com/jbkahn/flake8-print) as development requirement to enforce the lg policy. Use `# noqa: T2` for relevant print statements