### PR TITLE
Handle missing changelog when latest is passed

### DIFF
--- a/qgispluginci/exceptions.py
+++ b/qgispluginci/exceptions.py
@@ -1,24 +1,4 @@
-class TranslationFailed(Exception):
-    pass
-
-
-class TransifexNoResource(Exception):
-    pass
-
-
-class TransifexManyResources(Warning):
-    pass
-
-
-class GithubReleaseNotFound(Exception):
-    pass
-
-
-class GithubReleaseCouldNotUploadAsset(Exception):
-    pass
-
-
-class UncommitedChanges(Exception):
+class BuiltResourceInSources(Exception):
     pass
 
 
@@ -26,5 +6,29 @@ class ConfigurationNotFound(Exception):
     pass
 
 
-class BuiltResourceInSources(Exception):
+class GithubReleaseCouldNotUploadAsset(Exception):
+    pass
+
+
+class GithubReleaseNotFound(Exception):
+    pass
+
+
+class MissingChangelog(Exception):
+    pass
+
+
+class TransifexManyResources(Warning):
+    pass
+
+
+class TransifexNoResource(Exception):
+    pass
+
+
+class TranslationFailed(Exception):
+    pass
+
+
+class UncommitedChanges(Exception):
     pass

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -28,6 +28,7 @@ from qgispluginci.exceptions import (
     BuiltResourceInSources,
     GithubReleaseCouldNotUploadAsset,
     GithubReleaseNotFound,
+    MissingChangelog,
     UncommitedChanges,
 )
 from qgispluginci.parameters import Parameters
@@ -471,7 +472,10 @@ def release(
             parent_folder=Path(parameters.plugin_path).resolve().parent,
             changelog_path=parameters.changelog_path,
         )
-        release_version = parser.latest_version()
+        if parser.has_changelog():
+            release_version = parser.latest_version()
+        else:
+            release_version = "latest"
 
     release_tag = release_tag or release_version
 


### PR DESCRIPTION
This PR handles an edge-case that can be reproduced:

1. configure a plugin repo but do not create changelog
2. run qgis-plugin-ci package latest

Right now it raises a FileNotFoundError because there is no test against if changelog exists in this case.

In this case, the PR returns "latest" as release_version. Or should we consider that a changelog is mandatory?

Note: when #156 is merged, let's add a warning log message (or an error?).