### PR TITLE
Add same aliases to release as for package

### DIFF
--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -98,6 +98,7 @@ def main():
         help="The Github API token. If specified, the archive will be pushed to an already existing release.",
     )
     release_parser.add_argument(
+        "-r",
         "--create-plugin-repo",
         action="store_true",
         help="Will create a XML repo as a Github release asset. Github token is required.",
@@ -110,6 +111,7 @@ def main():
         "detected, a hard reset on a stash create will be used to revert changes made by qgis-plugin-ci.",
     )
     release_parser.add_argument(
+        "-d",
         "--disable-submodule-update",
         action="store_true",
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -103,6 +103,7 @@ def main():
         help="Will create a XML repo as a Github release asset. Github token is required.",
     )
     release_parser.add_argument(
+        "-c",
         "--allow-uncommitted-changes",
         action="store_true",
         help="If omitted, uncommitted changes are not allowed before releasing. If specified and some changes are "


### PR DESCRIPTION
I just realized that I had forgottent to add some aliases to the `release` subcommand also, as I did for `package` (https://github.com/opengisch/qgis-plugin-ci/pull/74)

This PR fix it.