### PR TITLE
Add option to use a custom plugin server

### DIFF
--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -7,6 +7,7 @@ usage: qgis-plugin-ci release [-h] [--transifex-token TRANSIFEX_TOKEN]
                               [--github-token GITHUB_TOKEN]
                               [--create-plugin-repo]
                               [--allow-uncommitted-changes]
+                              [--plugin-repo-url REPO_URL]
                               [--osgeo-username OSGEO_USERNAME]
                               [--osgeo-password OSGEO_PASSWORD]
                               release_version
@@ -34,6 +35,8 @@ optional arguments:
                         changes made by qgis-plugin-ci.
   -d --disable-submodule-update
                         If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.
+  --plgin-repo-url REPO_URL
+                        URL of the plugin repository on which to publish the plugin. If ommited defaults to plugins.qgis.org.
   --osgeo-username OSGEO_USERNAME
                         The Osgeo user name to publish the plugin.
   --osgeo-password OSGEO_PASSWORD

--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -3,40 +3,40 @@
 This command is specific for plugins hosted on GitHub.
 
 ```bash
-usage: qgis-plugin-ci release [-h] [--transifex-token TRANSIFEX_TOKEN]
-                              [--github-token GITHUB_TOKEN]
-                              [--create-plugin-repo]
-                              [--allow-uncommitted-changes]
-                              [--plugin-repo-url REPO_URL]
+usage: qgis-plugin-ci release [-h] [--release-tag RELEASE_TAG]
+                              [--transifex-token TRANSIFEX_TOKEN]
+                              [--github-token GITHUB_TOKEN] [-r] [-c] [-d]
+                              [--alternative-repo-url ALTERNATIVE_REPO_URL]
                               [--osgeo-username OSGEO_USERNAME]
                               [--osgeo-password OSGEO_PASSWORD]
                               release_version
 
 positional arguments:
-  release_version       The version to be released
+  release_version       The version to be released (x.y.z).
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --release-tag RELEASE_TAG
-                        The release tag (e.g. v1.2.3) can be specified if
-                        it is different from the release version (e.g. 1.2.3).
+                        The release tag, if different from the version (e.g. vx.y.z).
   --transifex-token TRANSIFEX_TOKEN
-                        The Transifex API token. If specified translations
-                        will be pulled and compiled.
+                        The Transifex API token. If specified translations will be pulled and
+                        compiled.
   --github-token GITHUB_TOKEN
-                        The Github API token. If specified, the archive will
-                        be pushed to an already existing release.
-  --create-plugin-repo  Will create a XML repo as a Github release asset.
-                        Github token is required.
-  -c --allow-uncommitted-changes
-                        If omitted, uncommitted changes are not allowed before
-                        releasing. If specified and some changes are detected,
-                        a hard reset on a stash create will be used to revert
-                        changes made by qgis-plugin-ci.
-  -d --disable-submodule-update
-                        If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.
-  --plgin-repo-url REPO_URL
-                        URL of the plugin repository on which to publish the plugin. If ommited defaults to plugins.qgis.org.
+                        The Github API token. If specified, the archive will be pushed to an
+                        already existing release.
+  -r, --create-plugin-repo
+                        Will create a XML repo as a Github release asset. Github token is
+                        required.
+  -c, --allow-uncommitted-changes
+                        If omitted, uncommitted changes are not allowed before releasing. If
+                        specified and some changes are detected, a hard reset on a stash
+                        create will be used to revert changes made by qgis-plugin-ci.
+  -d, --disable-submodule-update
+                        If omitted, a git submodule is updated. If specified, git submodules
+                        will not be updated/initialized before packaging.
+  --alternative-repo-url ALTERNATIVE_REPO_URL
+                        The URL of the endpoint to publish the plugin (defaults to
+                        plugins.qgis.org)
   --osgeo-username OSGEO_USERNAME
                         The Osgeo user name to publish the plugin.
   --osgeo-password OSGEO_PASSWORD

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -412,12 +412,16 @@ def create_plugin_repo(
     return xml_repo
 
 
-def upload_plugin_to_osgeo(username: str, password: str, archive: str):
+def upload_plugin_to_osgeo(
+    username: str, password: str, archive: str, server_url: str = None
+):
     """
     Upload the plugin to QGIS repository
 
     Parameters
     ----------
+    server_url
+        The plugin servers url (defaults to plugins.qgis.org)
     username
         The username
     password
@@ -425,7 +429,10 @@ def upload_plugin_to_osgeo(username: str, password: str, archive: str):
     archive
         The plugin archive file path to be uploaded
     """
-    address = f"https://{username}:{password}@plugins.qgis.org:443/plugins/RPC2/"
+    if not server_url:
+        address = f"https://{username}:{password}@plugins.qgis.org:443/plugins/RPC2/"
+    else:
+        address = f"http://{username}:{password}@{server_url}"
 
     server = xmlrpc.client.ServerProxy(
         address, verbose=(logger.getEffectiveLevel() <= 10)
@@ -469,6 +476,7 @@ def release(
     github_token: str = None,
     upload_plugin_repo_github: bool = False,
     transifex_token: str = None,
+    osgeo_url: str = None,
     osgeo_username: str = None,
     osgeo_password: str = None,
     allow_uncommitted_changes: bool = False,
@@ -494,6 +502,8 @@ def release(
         If set, this URL will be used to create the ZIP URL in the XML file
     transifex_token
         The Transifex token
+    osgeo_url
+        URL of the endpoint to upload the plugin to
     osgeo_username
         osgeo username to upload the plugin to official QGIS repository
     osgeo_password
@@ -608,8 +618,12 @@ def release(
                 username=osgeo_username,
                 password=osgeo_password,
                 archive=experimental_archive_name,
+                server_url=osgeo_url,
             )
         else:
             upload_plugin_to_osgeo(
-                username=osgeo_username, password=osgeo_password, archive=archive_name
+                username=osgeo_username,
+                password=osgeo_password,
+                archive=archive_name,
+                server_url=osgeo_url,
             )

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -432,7 +432,7 @@ def upload_plugin_to_osgeo(
     if not server_url:
         address = f"https://{username}:{password}@plugins.qgis.org:443/plugins/RPC2/"
     else:
-        address = f"http://{username}:{password}@{server_url}"
+        address = f"https://{username}:{password}@{server_url}"
 
     server = xmlrpc.client.ServerProxy(
         address, verbose=(logger.getEffectiveLevel() <= 10)

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -476,7 +476,7 @@ def release(
     github_token: str = None,
     upload_plugin_repo_github: bool = False,
     transifex_token: str = None,
-    osgeo_url: str = None,
+    plugin_repo_url: str = None,
     osgeo_username: str = None,
     osgeo_password: str = None,
     allow_uncommitted_changes: bool = False,
@@ -502,7 +502,7 @@ def release(
         If set, this URL will be used to create the ZIP URL in the XML file
     transifex_token
         The Transifex token
-    osgeo_url
+    plugin_repo_url
         URL of the endpoint to upload the plugin to
     osgeo_username
         osgeo username to upload the plugin to official QGIS repository
@@ -618,12 +618,12 @@ def release(
                 username=osgeo_username,
                 password=osgeo_password,
                 archive=experimental_archive_name,
-                server_url=osgeo_url,
+                server_url=plugin_repo_url,
             )
         else:
             upload_plugin_to_osgeo(
                 username=osgeo_username,
                 password=osgeo_password,
                 archive=archive_name,
-                server_url=osgeo_url,
+                server_url=plugin_repo_url,
             )

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -421,7 +421,7 @@ def upload_plugin_to_osgeo(
     Parameters
     ----------
     server_url
-        The plugin servers url (defaults to plugins.qgis.org)
+        The plugin server URL (defaults to plugins.qgis.org)
     username
         The username
     password

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -430,9 +430,8 @@ def upload_plugin_to_osgeo(
         The plugin archive file path to be uploaded
     """
     if not server_url:
-        address = f"https://{username}:{password}@plugins.qgis.org:443/plugins/RPC2/"
-    else:
-        address = f"https://{username}:{password}@{server_url}"
+        server_url = "plugins.qgis.org:443/plugins/RPC2/"
+    address = f"https://{username}:{password}@{server_url}"
 
     server = xmlrpc.client.ServerProxy(
         address, verbose=(logger.getEffectiveLevel() <= 10)

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -476,7 +476,7 @@ def release(
     github_token: str = None,
     upload_plugin_repo_github: bool = False,
     transifex_token: str = None,
-    plugin_repo_url: str = None,
+    alternative_repo_url: str = None,
     osgeo_username: str = None,
     osgeo_password: str = None,
     allow_uncommitted_changes: bool = False,
@@ -502,7 +502,7 @@ def release(
         If set, this URL will be used to create the ZIP URL in the XML file
     transifex_token
         The Transifex token
-    plugin_repo_url
+    alternative_repo_url
         URL of the endpoint to upload the plugin to
     osgeo_username
         osgeo username to upload the plugin to official QGIS repository
@@ -618,12 +618,12 @@ def release(
                 username=osgeo_username,
                 password=osgeo_password,
                 archive=experimental_archive_name,
-                server_url=plugin_repo_url,
+                server_url=alternative_repo_url,
             )
         else:
             upload_plugin_to_osgeo(
                 username=osgeo_username,
                 password=osgeo_password,
                 archive=archive_name,
-                server_url=plugin_repo_url,
+                server_url=alternative_repo_url,
             )

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -117,7 +117,7 @@ def main():
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",
     )
     release_parser.add_argument(
-        "--osgeo-url",
+        "--plugin-repo-url",
         help="The URL of the endpoint to publish the plugin (defaults to plugins.qgis.org)",
     )
     release_parser.add_argument(

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -117,7 +117,7 @@ def main():
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",
     )
     release_parser.add_argument(
-        "--plugin-repo-url",
+        "--alternative-repo-url",
         help="The URL of the endpoint to publish the plugin (defaults to plugins.qgis.org)",
     )
     release_parser.add_argument(
@@ -222,7 +222,7 @@ def main():
             transifex_token=args.transifex_token,
             github_token=args.github_token,
             upload_plugin_repo_github=args.create_plugin_repo,
-            plugin_repo_url=args.plugin_repo_url,
+            alternative_repo_url=args.alternative_repo_url,
             osgeo_username=args.osgeo_username,
             osgeo_password=args.osgeo_password,
             allow_uncommitted_changes=args.allow_uncommitted_changes,

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -222,7 +222,7 @@ def main():
             transifex_token=args.transifex_token,
             github_token=args.github_token,
             upload_plugin_repo_github=args.create_plugin_repo,
-            osgeo_url=args.osgeo_url,
+            plugin_repo_url=args.plugin_repo_url,
             osgeo_username=args.osgeo_username,
             osgeo_password=args.osgeo_password,
             allow_uncommitted_changes=args.allow_uncommitted_changes,

--- a/scripts/qgis_plugin_ci.py
+++ b/scripts/qgis_plugin_ci.py
@@ -117,6 +117,10 @@ def main():
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",
     )
     release_parser.add_argument(
+        "--osgeo-url",
+        help="The URL of the endpoint to publish the plugin (defaults to plugins.qgis.org)",
+    )
+    release_parser.add_argument(
         "--osgeo-username", help="The Osgeo user name to publish the plugin."
     )
     release_parser.add_argument(
@@ -218,6 +222,7 @@ def main():
             transifex_token=args.transifex_token,
             github_token=args.github_token,
             upload_plugin_repo_github=args.create_plugin_repo,
+            osgeo_url=args.osgeo_url,
             osgeo_username=args.osgeo_username,
             osgeo_password=args.osgeo_password,
             allow_uncommitted_changes=args.allow_uncommitted_changes,


### PR DESCRIPTION
This PR adds the option `--osgeo-url` to allow the plugin to be uploaded to different server than the default `plugins.qgis.org`.

If the flag is omitted the release will be uploaded to the server at `plugins.qgis.org` as usual.

