### PR TITLE
Documentation: modernize CI and add credits page with automatic dependencies listing

### DIFF
--- a/.github/workflows/docs_builder.yml
+++ b/.github/workflows/docs_builder.yml
@@ -13,7 +13,9 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - ".github/workflows/documentation.yml"
+      - ".github/workflows/docs_builder.yml"
+      - docs/**/*
+      - requirements/documentation.txt
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -77,13 +79,16 @@ jobs:
 
     - name: Setup Pages
       uses: actions/configure-pages@v3
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       with:
         # Upload entire repository
         path: docs/_build/html/
 
     - name: Deploy to GitHub Pages
       id: deployment
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
       uses: actions/deploy-pages@v1

--- a/.github/workflows/docs_builder.yml
+++ b/.github/workflows/docs_builder.yml
@@ -1,4 +1,4 @@
-name: Documentation Builder
+name: "📚 Documentation Builder"
 
 on:
   push:
@@ -7,16 +7,32 @@ on:
       - 'docs/**/*'
       - '.github/workflows/docs_builder.yml'
       - 'qgispluginci/**/*.py'
-    tags: "*"
+    tags:
+      - "*"
+
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/documentation.yml"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.11
 
 jobs:
   build-docs:
 
-    runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
 
     steps:
     - name: Get source code
@@ -27,24 +43,47 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: "pip"
-
-    - name: Cache project dependencies (pip)
-      uses: actions/cache@v3.2.4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache-dependency-path: "requirements/*.txt"
 
     - name: Install project requirements
       run: |
         python -m pip install -U pip setuptools wheel
+        python -m pip install -U -r requirements.txt
+
+    - name: Install project as a package
+      run: python -m pip install -e .
+
+    # this job must run before installing other dependencies to avoid listing everything
+    - name: Generates licenses page with pip-licences
+      run: |
+        python -m pip install -U "pip-licenses>=4,<5"
+        pip-licenses --format=markdown --with-authors --with-description --with-urls --ignore-packages qgis-plugin-ci --output-file=docs/misc/licenses.md
+
+    - name: Install documentation requirements
+      run: |
+        python -m pip install -U -r requirements/development.txt
         python -m pip install -U -r requirements/documentation.txt
 
     - name: Build doc using Sphinx
-      run: sphinx-build -b html docs docs/_build/html
+      run: sphinx-build -b html -j auto -d docs/_build/cache -q docs docs/_build/html
+
+    - name: Save build doc as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: documentation
+        path: docs/_build/html/*
+        if-no-files-found: error
+        retention-days: 30
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        # Upload entire repository
+        path: docs/_build/html/
 
     - name: Deploy to GitHub Pages
-      run: |
-        python -m pip install ghp-import
-        ghp-import --force --no-jekyll --push docs/_build/html
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ usage/ci_travis
 caption: Miscellaneous
 maxdepth: 1
 ---
+misc/credits
 misc/faq
 ```
 
@@ -67,7 +68,9 @@ development/testing
 development/history
 ```
 
-## Examples
+----
+
+## Plugins published using qgis-plugin-ci
 
 ```{eval-rst}
 .. panels::

--- a/docs/misc/credits.md
+++ b/docs/misc/credits.md
@@ -1,0 +1,11 @@
+# Credits
+
+- [Python 3](https://www.python.org/)
+
+## Dependencies
+
+> Generated with [pip-licenses](https://pypi.org/project/pip-licenses/)
+
+```{include} licenses.md
+
+```


### PR DESCRIPTION
In this PR:

- use pip-licenses to fill a table of dependencies in a new credits page
- modernize CI to use the new GH Actions to publish to GitHub Pages (outside gh-pages branch)
- publish the doc only on tags (to avoid difference between published info and features accessible through published packaged)

Render of credits page (local so with full dev dependencies):

![image](https://user-images.githubusercontent.com/1596222/218128907-c707c78a-fe8d-4b08-929e-afad1361af39.png)


I know, the page width is clearly an issue but, still we could improve it later.