### PR TITLE
Docs/switch to furo

### DIFF
--- a/.github/workflows/docs_builder.yml
+++ b/.github/workflows/docs_builder.yml
@@ -63,7 +63,6 @@ jobs:
 
     - name: Install documentation requirements
       run: |
-        python -m pip install -U -r requirements/development.txt
         python -m pip install -U -r requirements/documentation.txt
 
     - name: Build doc using Sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,6 @@ from os import environ, path
 
 sys.path.insert(0, path.abspath(".."))  # move into project package
 
-# 3rd party
-import sphinx_rtd_theme  # noqa: F401 theme of Read the Docs
-
 # Package
 from qgispluginci import __about__
 
@@ -21,21 +18,11 @@ from qgispluginci import __about__
 on_rtd = environ.get("READTHEDOCS", None) == "True"
 
 # -- Project information -----------------------------------------------------
-project = __about__.__title__
 author = __about__.__author__
 copyright = __about__.__copyright__
+project = __about__.__title__
 version = release = __about__.__version__
-github_doc_root = "{}/tree/master/doc/".format(__about__.__uri__)
 
-myst_substitutions = {
-    "author": author,
-    "date_update": datetime.now().strftime("%d %B %Y"),
-    "repo_url": __about__.__uri__,
-    "title": project,
-    "version": version,
-}
-
-myst_url_schemes = ("http", "https", "mailto")
 
 # -- General configuration ---------------------------------------------------
 
@@ -47,15 +34,12 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.githubpages",
-    "sphinx.ext.imgmath",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
-    "sphinx.ext.viewcode",
     # 3rd party
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",
-    "sphinx_rtd_theme",
 ]
 
 
@@ -87,40 +71,50 @@ pygments_style = "sphinx"
 
 # -- Theme
 
-# html_favicon = "../qgispluginci/resources/images/icon.png"
-# html_logo = "../qgispluginci/resources/images/icon.png"
-# html_static_path = ["_static"]
-html_theme = "sphinx_rtd_theme"
+# final URL
+html_baseurl = __about__.__uri_homepage__
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ["static"]
+html_extra_path = ["robots.txt"]
+
+# theme
+html_theme = "furo"
 html_theme_options = {
-    # "canonical_url": __about__.__uri_homepage__,
-    "display_version": True,
-    # "github_url": __about__.__uri__,
-    "logo_only": False,
-    "prev_next_buttons_location": "both",
-    # "repository_url": __about__.__uri__,
-    "style_external_links": True,
-    "style_nav_header_background": "SteelBlue",
-    # Toc options
-    "collapse_navigation": False,
-    "includehidden": False,
-    "navigation_depth": 4,
-    "sticky_navigation": False,
-    "titles_only": False,
+    "navigation_with_keys": True,
+    "source_repository": __about__.__uri__,
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 
 
+# -- EXTENSIONS --------------------------------------------------------
+
 myst_enable_extensions = [
-    "amsmath",
     "colon_fence",
     "deflist",
-    "dollarmath",
     "html_image",
     "linkify",
     "replacements",
     "smartquotes",
     "substitution",
 ]
-# -- EXTENSIONS --------------------------------------------------------
+
+myst_heading_anchors = 3
+
+# replacement variables
+myst_substitutions = {
+    "author": author,
+    "date_update": datetime.now().strftime("%d %B %Y"),
+    "description": __about__.__summary__,
+    "repo_url": __about__.__uri__,
+    "title": project,
+    "version": version,
+}
+
+myst_url_schemes = ("http", "https", "mailto")
 
 # Configuration for intersphinx (refer to others docs).
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 # {{ title }} - Documentation
 
+> **Description:** {{ description }}  
 > **Author and contributors:** {{ author }}  
 > **Version:** {{ version }}  
 > **Source code:** {{ repo_url }}  

--- a/docs/usage/cli_package.md
+++ b/docs/usage/cli_package.md
@@ -37,7 +37,7 @@ When packaging the plugin, some extra metadata information can be added if these
 * `commitSha1=` : the commit ID
 * `dateTime=` : the date time in UTC format when the packaging is done
 
-* :::{tip}
+:::{tip}
 These extra parameters are specific to QGIS Plugin CI, so it's strongly recommended storing them below a dedicated section:
 
 ```ini
@@ -46,4 +46,5 @@ commitNumber=
 commitSha1=
 dateTime=
 ```
+
 :::

--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -51,7 +51,7 @@ When packaging the plugin, some extra metadata information can be added if these
 * `commitSha1=` : the commit ID
 * `dateTime=` : the date time in UTC format when the packaging is done
 
-* :::{tip}
+:::{tip}
 These extra parameters are specific to QGIS Plugin CI, so it's strongly recommended storing them below a dedicated section:
 
 ```ini
@@ -60,4 +60,5 @@ commitNumber=
 commitSha1=
 dateTime=
 ```
+
 :::

--- a/qgispluginci/__about__.py
+++ b/qgispluginci/__about__.py
@@ -35,13 +35,16 @@ __email__ = "denis.rouzaud@gmail.com"
 __license__ = "GNU General Public License v3.0"
 __summary__ = (
     "Let qgis-plugin-ci package and release your QGIS plugins for you. "
-    "Have a tea or go hiking meanwhile."
+    "Have a tea or go hiking meanwhile.\n"
     "Contains scripts to perform automated testing and deployment for QGIS plugins. "
-    "These scripts are written for and tested on GitHub, Travis-CI, GitHub workflows and Transifex."
+    "These scripts are written for and tested on GitHub Actions, GitLab CI, "
+    "Travis-CI, and Transifex."
 )
 __title__ = "QGIS Plugin CI"
 __title_clean__ = "".join(e for e in __title__ if e.isalnum())
 __uri__ = "https://github.com/opengisch/qgis-plugin-ci/"
+__uri_homepage__ = "https://opengisch.github.io/qgis-plugin-ci/"
+__uri_tracker__ = f"{__uri__}issues/"
 
 # This string might be updated on CI on runtime with a proper semantic version name with X.Y.Z
 __version__ = "__VERSION__"

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,11 +1,10 @@
 # Documentation (for devs)
 # -----------------------
 
+furo==2022.*
 myst-parser[linkify]>=0.13,<0.19
 sphinx>=3.1,<7
 sphinx-autobuild==2021.3.14
 sphinx-autodoc-typehints>=1.11,<1.23
 sphinx-copybutton>=0.2,<1
 sphinx-design>=0.3,<0.4
-sphinx-markdown-tables>=0.0.15,<0.1
-sphinx-rtd-theme>=0.5,<2

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -5,6 +5,5 @@ furo==2022.*
 myst-parser[linkify]>=0.13,<0.19
 sphinx>=3.1,<7
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints>=1.11,<1.23
 sphinx-copybutton>=0.2,<1
 sphinx-design>=0.3,<0.4

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ setup(
     version=VERSION,
     url=__about__.__uri__,
     project_urls={
-        "Docs": "https://opengisch.github.io/qgis-plugin-ci/",
-        "Bug Reports": "{}issues/".format(__about__.__uri__),
+        "Docs": __about__.__uri_homepage__,
+        "Bug Reports": __about__.__uri_tracker__,
         "Source": __about__.__uri__,
     },
     download_url="https://github.com/opengisch/qgis-plugin-ci/archive/{}.tar.gz".format(


### PR DESCRIPTION
In this PR:

- use [Furo](https://pradyunsg.me/furo/) instead of Read The Docs theme. Reasons:
  - better width
  - feel more modern and cleaner
  - dark/light/auto theme
  - personal preference
  - really clean and maintained code
- remove useless documentation dependencies
- improve package modular metadata to get doc and tracker URLs both in doc conf and setup
- fix typos

![image](https://user-images.githubusercontent.com/1596222/218491219-db64f919-c691-43bc-822c-42328e4f6516.png)

![image](https://user-images.githubusercontent.com/1596222/218491306-0cde0682-c39d-4704-93c8-d5f5f30bcc63.png)
