### PR TITLE
Improvment: if no version set, use a pseudo dev inherited from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,13 +69,6 @@ jobs:
       - name: Get source code
         uses: actions/checkout@v3
 
-      - name: Set version number
-        run: |
-          VERSION=${GITHUB_REF:-0.0.0}
-          VERSION=${VERSION##*/}
-          sed -i "s/__VERSION__/${VERSION}/g" setup.py
-          sed -i "s/__VERSION__/${VERSION}/g" qgispluginci/__about__.py
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 <!-- ## Unreleased [{version_tag}](https://github.com/opengisch/qgis-plugin-ci/releases/tag/{version_tag}) - YYYY-MM-DD -->
 
-## Unreleased
+## 2.5.4 - 2023-02-10
+
+### Bugs fixes 🐛
+
+* Modernize build and packaging to publish as wheel by @Guts in <https://github.com/opengisch/qgis-plugin-ci/pull/191>
 
 ## 2.5.3 - 2023-02-10
 

--- a/qgispluginci/__about__.py
+++ b/qgispluginci/__about__.py
@@ -65,14 +65,14 @@ if "." not in __version__:
     try:
         git_cmd = "git tag -l --sort=-creatordate | head -n 1"
         returned_output: bytes = subprocess.check_output(git_cmd, shell=True)
-        if len(returned_output):
-            __version__ = returned_output.decode("utf-8")
-        else:
-            chglog = ChangelogParser(parent_folder=Path(__file__).parent.parent)
-            if chglog.CHANGELOG_FILEPATH:
-                __version__ = chglog.latest_version()
+        __version__ = returned_output.decode("utf-8")
     except Exception as err:
         logging.debug(f"Unable to retrieve version from latest git tag. Trace: {err}")
+
+    if not len(__version__):
+        chglog = ChangelogParser(parent_folder=Path(__file__).parent.parent)
+        if chglog.CHANGELOG_FILEPATH:
+            __version__ = chglog.latest_version()
 
     try:
         # bump latest number

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ with open(HERE / "requirements/development.txt") as f:
 
 python_min_version = (3, 7)
 
-# This string might be updated on CI on runtime with a proper semantic version name with X.Y.Z
 VERSION = __about__.__version__
 
 # ############################################################################

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,7 @@ with open(HERE / "requirements/development.txt") as f:
 python_min_version = (3, 7)
 
 # This string might be updated on CI on runtime with a proper semantic version name with X.Y.Z
-VERSION = "__VERSION__"
-
-if "." not in VERSION:
-    # If VERSION is still not a proper semantic versioning with X.Y.Z
-    # let's hardcode 0.0.0
-    VERSION = "0.0.0"
+VERSION = __about__.__version__
 
 # ############################################################################
 # ########## Setup #############


### PR DESCRIPTION
This PR improves version number retriever in __about__ module:

- if version is not defined or seems to be an invalid semver version, it tries to get the latest git tag
- if git tag fails (git not installed or with a limited fetch depth), it tries to read the latest version from the changelog
- if success, it tries to bump the latest version

Goal? Avoid this 0.0.0 number which leads to confusion in usage or doc.


## Results

In dev mode:

```sh
> pip install -e .
Successfully installed qgis-plugin-ci-2.5.5.dev0
```

In doc:

![image](https://user-images.githubusercontent.com/1596222/218513644-33d3ed5c-1d36-4f24-b24c-c6efb67a8402.png)

