### PR TITLE
fix docs for Qt dependencies in github actions

### DIFF
--- a/docs/usage/ci_github.md
+++ b/docs/usage/ci_github.md
@@ -27,7 +27,7 @@ jobs:
        # - name: Install Qt lrelease
        #   run: |
        #    sudo apt-get update
-       #    sudo apt-get install qt5-default qttools5-dev-tools
+       #    sudo apt-get install qtbase5-dev qttools5-dev-tools
 
       - name: Install qgis-plugin-ci
         run: pip3 install qgis-plugin-ci

--- a/docs/usage/ci_github.md
+++ b/docs/usage/ci_github.md
@@ -27,7 +27,7 @@ jobs:
        # - name: Install Qt lrelease
        #   run: |
        #    sudo apt-get update
-       #    sudo apt-get install qtbase5-dev qttools5-dev-tools
+       #    sudo apt-get install qt5-make qttools5-dev-tools
 
       - name: Install qgis-plugin-ci
         run: pip3 install qgis-plugin-ci


### PR DESCRIPTION
qt5-default does not exist in 22.04 (and in this repo, CI uses qtbase5-dev so I guess it must replace it ?)