### PR TITLE
Return a different exit code if the upload to qgis.org has failed

### DIFF
--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -43,6 +43,8 @@ options:
                         The Osgeo password to publish the plugin.
 ```
 
+If the exit code is `2`, it means the upload to the QGIS server has failed.
+
 ## Additional metadata
 
 When packaging the plugin, some extra metadata information can be added if these keys are present in the `metadata.txt`:

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -452,7 +452,7 @@ def upload_plugin_to_osgeo(
             f"Plugin path: {archive}"
         )
         logger.error(err_msg)
-        sys.exit(err_msg)
+        sys.exit(2)
     except xmlrpc.client.Fault as err:
         err_msg = (
             "=== A fault occurred occurred ===\n"
@@ -461,7 +461,7 @@ def upload_plugin_to_osgeo(
             f"Plugin path: {archive}"
         )
         logger.error(err_msg)
-        sys.exit(err_msg)
+        sys.exit(2)
 
 
 def release(


### PR DESCRIPTION
While writing this quick PR, I was pretty sure I have a opened ticket either in this repository or in the QGIS django repository, but I couldn't find any :(

Only this commit as reference : https://github.com/opengisch/qgis-plugin-ci/commit/64216b5e994a7ec0c90efb34cfe850639d851ade with some discussions.

Everytime I release a new version of QuickOSM, it failed on the upload to the OSGEO server.
The logs from qgis-plugin-ci are not enough (my commit above trying to increase some debug).

We do not need to send the message twice, with the logger and with the sys.exist. I think the logger is enough, no ?
We can read twice `=== A protocol error occurred ===`

Exemple : 

```

Run qgis-plugin-ci release 2.2.2 --github-token *** --transifex-token *** --osgeo-username *** --osgeo*** --create-plugin-repo
  qgis-plugin-ci release 2.2.2 --github-token *** --transifex-token *** --osgeo-username *** --osgeo*** --create-plugin-repo
  shell: /usr/bin/bash -e {0}
  env:
    RELEASE_VERSION: 2.2.2
    pythonLocation: /opt/hostedtoolcache/Python/3.10.10/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.10/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.10/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.10/x64/lib
Plugin archive created: QuickOSM.2.2.2.zip (6.54 Mo)
2023-04-11 14:00:56||ERROR||release||=== A protocol error occurred ===
URL: ***:******@plugins.qgis.org:443/plugins/RPC2/
HTTP/HTTPS headers: {'Date': 'Tue, 11 Apr 2023 14:00:56 GMT', 'Content-Type': 'text/html; charset=utf-8', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Vary': 'Cookie', 'Set-Cookie': 'sessionid=8pn06204q3417g96g1o3odivmrj9094j; expires=Tue, 25 Apr 2023 14:00:56 GMT; HttpOnly; Max-Age=1209600; Path=/; SameSite=Lax', 'CF-Cache-Status': 'DYNAMIC', 'Report-To': '{"endpoints":[{"url":"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sW8X9n%2FSbaxNLLe7E5edIubdCiTyUWeyQkbHwu%2FuY1Kul1YXFKcPVcKFwnydtiAKwwnYzwqDN9Xmv0Zv77pXeHikPNDAk8L9wJ781odRhpVYrk%2BVEMU87UMZJNJ9yE6nR5yS"}],"group":"cf-nel","max_age":604800}', 'NEL': '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}', 'Server': 'cloudflare', 'CF-RAY': '7b63c219dcf84864-DFW', 'alt-svc': 'h3=":443"; ma=86400, h3-29=":443"; ma=86400'}
Error code: 400
Error message: Bad Request
Plugin path: QuickOSM.2.2.2.zip
=== A protocol error occurred ===
URL: ***:******@plugins.qgis.org:443/plugins/RPC2/
HTTP/HTTPS headers: {'Date': 'Tue, 11 Apr 2023 14:00:56 GMT', 'Content-Type': 'text/html; charset=utf-8', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Vary': 'Cookie', 'Set-Cookie': 'sessionid=8pn06204q3417g96g1o3odivmrj9094j; expires=Tue, 25 Apr 2023 14:00:56 GMT; HttpOnly; Max-Age=1209600; Path=/; SameSite=Lax', 'CF-Cache-Status': 'DYNAMIC', 'Report-To': '{"endpoints":[{"url":"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=sW8X9n%2FSbaxNLLe7E5edIubdCiTyUWeyQkbHwu%2FuY1Kul1YXFKcPVcKFwnydtiAKwwnYzwqDN9Xmv0Zv77pXeHikPNDAk8L9wJ781odRhpVYrk%2BVEMU87UMZJNJ9yE6nR5yS"}],"group":"cf-nel","max_age":604800}', 'NEL': '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}', 'Server': 'cloudflare', 'CF-RAY': '7b63c219dcf84864-DFW', 'alt-svc': 'h3=":443"; ma=86400, h3-29=":443"; ma=86400'}
Error code: 400
Error message: Bad Request
Plugin path: QuickOSM.2.2.2.zip
Error: Process completed with exit code 1.
```

From a CI point of view, I would like know if it was only the upload to qgis.org which failed with a specific exit code.

I can still create a issue on QGIS-Django repository.