### PR TITLE
Set encoding of `request.get` result to `utf-8`

### DIFF
--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -135,7 +135,8 @@ class TransifexClient(BaseClient):
 
         r = requests.get(url)
         # transifex returns None encoding and the apparent_encoding is Windows-1254 what leads to malformed result strings. So we set the encoding hardcoded to utf-8.
-        r.encoding = "utf-8"
+        if not r.encoding:
+            r.encoding = "utf-8"
         translated_content = r.text
         with open(path_to_output_file, "w") as fh:
             fh.write(translated_content)

--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -133,7 +133,9 @@ class TransifexClient(BaseClient):
             resource=self.get_resource(), language=language
         )
 
-        translated_content = requests.get(url).text
+        r = requests.get(url)
+        r.encoding = 'utf-8'
+        translated_content = r.text
         with open(path_to_output_file, "w") as fh:
             fh.write(translated_content)
 

--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -134,6 +134,7 @@ class TransifexClient(BaseClient):
         )
 
         r = requests.get(url)
+        # transifex returns None encoding and the apparent_encoding is Windows-1254 what leads to malformed result strings. So we set the encoding hardcoded to utf-8.
         r.encoding = "utf-8"
         translated_content = r.text
         with open(path_to_output_file, "w") as fh:

--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -134,7 +134,7 @@ class TransifexClient(BaseClient):
         )
 
         r = requests.get(url)
-        r.encoding = 'utf-8'
+        r.encoding = "utf-8"
         translated_content = r.text
         with open(path_to_output_file, "w") as fh:
             fh.write(translated_content)


### PR DESCRIPTION
This fixes that the encoding of umlauts where broken in the ts files.

Fixes https://github.com/opengisch/QgisModelBaker/issues/799