### PR TITLE
Fix tag for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       # -- FROM HERE, A TAG IS REQUIRED ---
       - name: Deploy to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
 
         with:
           user: __token__


### PR DESCRIPTION
v1 is not valid, release/v1 must be used instead.