### PR TITLE
Support for pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,8 @@ commands:
 
 - The code is under a **git** repository (`git archive` is used to bundle the plugin).
 - There is no uncommitted changes when doing a package/release (althought there is an option to bypass this requirement).
-- A configuration at the top directory either in `.qgis-plugin-ci` or in `setup.cfg` or `pyproject.toml` with a `[qgis-plugin-ci]` section with the following fields:
-    - github_organization_slug (unless you're running from Travis CI)
-    - plugin_path
-    - project_slug (unless you're running from Travis CI)
-- The source files of the plugin are within a sub-directory, with among others, a `metadata.txt` file with the following fields:
+- A configuration at the top directory either in `.qgis-plugin-ci` or in `setup.cfg` or `pyproject.toml` with a `[qgis-plugin-ci]` section (see `docs/configuration/options.md` for details).
+- The source files of the plugin are within a sub-directory  with a `metadata.txt` file with the following fields:
     - description
     - qgisMinimumVersion
     - repository

--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@ commands:
 
 ## Requirements
 
-- The code is under a **git** repository (`git archive` is used to bundle the plugin)
-- There is no uncommitted changes when doing a package/release (there is an option to allow this)
-- A configuration at the top directory either in `.qgis-plugin-ci` or in `setup.cfg` with a `[qgis-plugin-ci]` section.
-- The source files of the plugin are within a sub-directory. The name of this directory will be used for the zip file.
+- The code is under a **git** repository (`git archive` is used to bundle the plugin).
+- There is no uncommitted changes when doing a package/release (althought there is an option to bypass this requirement).
+- A configuration at the top directory either in `.qgis-plugin-ci` or in `setup.cfg` or `pyproject.toml` with a `[qgis-plugin-ci]` section with the following fields:
+    - github_organization_slug (unless you're running from Travis CI)
+    - plugin_path
+    - project_slug (unless you're running from Travis CI)
+- The source files of the plugin are within a sub-directory, with among others, a `metadata.txt` file with the following fields:
+    - description
+    - qgisMinimumVersion
+    - repository
+	- tracker
+
+See `parameters.py` for more parameters and details. Notice that the name of this directory will be used for the zip file.
 
 ## QRC and UI files
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1,9 +1,10 @@
 # Settings
 
-The plugin must have a configuration, located at the top directory:
+The plugin must have a configuration, located at the top directory; it can be either:
 
-- either you use a `.qgis-plugin-ci` YAML file
-- or you use a `[qgis-plugin-ci]` section in a `setup.cfg` file (which is used by many other tools).
+- a YAML file named `.qgis-plugin-ci`
+- an INI file named `setup.cfg` with a `[qgis-plugin-ci]` section
+- a TOML file (= your actual `pyproject.toml` file) with a `[qgis-plugin-ci]` section.
 
 In the configuration, you should at least provide the following configuration:
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -47,3 +47,11 @@ plugin_path = QuickOSM
 github_organization_slug = 3liz
 project_slug = QuickOSM
 ```
+### Using TOML file `pyproject.toml`
+
+```toml
+[qgis-plugin-ci]
+plugin_path = "qgis_plugin_ci_testing"
+github_organization_slug = "opengisch"
+project_slug = "qgis-plugin-ci"
+```

--- a/qgispluginci/cli.py
+++ b/qgispluginci/cli.py
@@ -4,9 +4,9 @@ import logging
 from importlib.metadata import version
 
 from qgispluginci.changelog import ChangelogParser
+from qgispluginci.parameters import Parameters
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
-from qgispluginci.utils import make_parameters
 
 __version__ = version("qgis-plugin-ci")
 __title__ = "QGISPluginCI"
@@ -164,7 +164,7 @@ def cli():
     exit_val = 0
 
     # Initialize Parameters
-    parameters = make_parameters(args)
+    parameters = Parameters.make_from(args=args)
     # CHANGELOG
     if args.command == "changelog":
         try:

--- a/qgispluginci/cli.py
+++ b/qgispluginci/cli.py
@@ -1,18 +1,12 @@
 #!/usr/bin/env python3
-
 import argparse
-import configparser
 import logging
-import os
 from importlib.metadata import version
 
-import yaml
-
 from qgispluginci.changelog import ChangelogParser
-from qgispluginci.exceptions import ConfigurationNotFound
-from qgispluginci.parameters import Parameters
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
+from qgispluginci.utils import make_parameters
 
 __version__ = version("qgis-plugin-ci")
 __title__ = "QGISPluginCI"
@@ -169,28 +163,8 @@ def cli():
 
     exit_val = 0
 
-    if os.path.isfile(".qgis-plugin-ci"):
-        # We read the .qgis-plugin-ci file
-        with open(".qgis-plugin-ci", encoding="utf8") as f:
-            arg_dict = yaml.safe_load(f)
-    else:
-        config = configparser.ConfigParser()
-        config.read("setup.cfg")
-        if "qgis-plugin-ci" in config.sections():
-            # We read the setup.cfg file
-            arg_dict = dict(config.items("qgis-plugin-ci"))
-        else:
-            # We don't have either a .qgis-plugin-ci or a setup.cfg
-            if args.command == "changelog":
-                # but for the "changelog" sub command, the config file is not required, we can continue
-                arg_dict = dict()
-            else:
-                raise ConfigurationNotFound(
-                    ".qgis-plugin-ci or setup.cfg with a 'qgis-plugin-ci' section have not been found."
-                )
-
-    parameters = Parameters(arg_dict)
-
+    # Initialize Parameters
+    parameters = make_parameters(args)
     # CHANGELOG
     if args.command == "changelog":
         try:

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -142,8 +142,6 @@ class Parameters:
 
         def load_config(path_to_file: str) -> Dict[str, Any]:
             if "setup.cfg" in path_to_file:
-                with open(path_to_file) as fh:
-                    print(fh.read())
                 config = configparser.ConfigParser()
                 config.read(path_to_file)
                 return dict(config.items("qgis-plugin-ci"))

--- a/qgispluginci/utils.py
+++ b/qgispluginci/utils.py
@@ -1,11 +1,17 @@
+import configparser
 import logging
 import os
 import re
 from math import floor
 from math import log as math_log
 from math import pow
-from typing import Union
+from typing import Any, Dict, Optional, Union
 
+import toml
+import yaml
+
+from qgispluginci.exceptions import ConfigurationNotFound
+from qgispluginci.parameters import Parameters
 from qgispluginci.version_note import VersionNote
 
 # GLOBALS
@@ -27,6 +33,63 @@ def configure_file(source_file: str, dest_file: str, replace: dict):
         content = re.sub(pattern, new, content, flags=re.M)
     with open(dest_file, "w", encoding="utf-8") as f:
         f.write(content)
+
+
+def make_parameters(args=None, config_file: Optional[str] = None) -> Parameters:
+    """
+    Make a Dict from a config file or by exploring the filesystem
+    Accepts an argparse Namespace for backward compatibility.
+    """
+    configuration_not_found = ConfigurationNotFound(
+        ".qgis-plugin-ci or setup.cfg or pyproject.toml with a 'qgis-plugin-ci' section have not been found."
+    )
+
+    def explore_config() -> Dict[str, Any]:
+        if os.path.isfile(".qgis-plugin-ci"):
+            # We read the .qgis-plugin-ci file
+            with open(".qgis-plugin-ci", encoding="utf8") as f:
+                arg_dict = yaml.safe_load(f)
+        elif os.path.isfile("pyproject.toml"):
+            # We read the pyproject.toml file
+            with open("pyproject.toml", encoding="utf8") as f:
+                arg_dict = toml.load(f)
+        else:
+            config = configparser.ConfigParser()
+            config.read("setup.cfg")
+            if "qgis-plugin-ci" in config.sections():
+                # We read the setup.cfg file
+                arg_dict = dict(config.items("qgis-plugin-ci"))
+            else:
+                # We don't have either a .qgis-plugin-ci or a setup.cfg
+                if args and args.command == "changelog":
+                    # but for the "changelog" sub command, the config file is not required, we can continue
+                    arg_dict = dict()
+                else:
+                    raise configuration_not_found
+        return arg_dict
+
+    def load_config(filename: str) -> Dict[str, Any]:
+        if filename == "setup.cfg":
+            config = configparser.ConfigParser()
+            config.read(filename)
+            return dict(config.items("qgis-plugin-ci"))
+
+        _, suffix = filename.rsplit(".", 1)
+
+        with open(filename) as f:
+            if suffix == "toml":
+                return toml.load(f)
+            elif suffix in {"yaml", "yml"}:
+                return yaml.safe_load(f)
+
+        raise configuration_not_found
+
+    if config_file:
+        config_dict = load_config(config_file)
+    else:
+        config_dict = explore_config()
+
+    return Parameters(config_dict)
 
 
 def convert_octets(octets: int) -> str:

--- a/qgispluginci/utils.py
+++ b/qgispluginci/utils.py
@@ -1,17 +1,11 @@
-import configparser
 import logging
 import os
 import re
 from math import floor
 from math import log as math_log
 from math import pow
-from typing import Any, Dict, Optional, Union
+from typing import Union
 
-import toml
-import yaml
-
-from qgispluginci.exceptions import ConfigurationNotFound
-from qgispluginci.parameters import Parameters
 from qgispluginci.version_note import VersionNote
 
 # GLOBALS
@@ -33,63 +27,6 @@ def configure_file(source_file: str, dest_file: str, replace: dict):
         content = re.sub(pattern, new, content, flags=re.M)
     with open(dest_file, "w", encoding="utf-8") as f:
         f.write(content)
-
-
-def make_parameters(args=None, config_file: Optional[str] = None) -> Parameters:
-    """
-    Make a Dict from a config file or by exploring the filesystem
-    Accepts an argparse Namespace for backward compatibility.
-    """
-    configuration_not_found = ConfigurationNotFound(
-        ".qgis-plugin-ci or setup.cfg or pyproject.toml with a 'qgis-plugin-ci' section have not been found."
-    )
-
-    def explore_config() -> Dict[str, Any]:
-        if os.path.isfile(".qgis-plugin-ci"):
-            # We read the .qgis-plugin-ci file
-            with open(".qgis-plugin-ci", encoding="utf8") as f:
-                arg_dict = yaml.safe_load(f)
-        elif os.path.isfile("pyproject.toml"):
-            # We read the pyproject.toml file
-            with open("pyproject.toml", encoding="utf8") as f:
-                arg_dict = toml.load(f)
-        else:
-            config = configparser.ConfigParser()
-            config.read("setup.cfg")
-            if "qgis-plugin-ci" in config.sections():
-                # We read the setup.cfg file
-                arg_dict = dict(config.items("qgis-plugin-ci"))
-            else:
-                # We don't have either a .qgis-plugin-ci or a setup.cfg
-                if args and args.command == "changelog":
-                    # but for the "changelog" sub command, the config file is not required, we can continue
-                    arg_dict = dict()
-                else:
-                    raise configuration_not_found
-        return arg_dict
-
-    def load_config(filename: str) -> Dict[str, Any]:
-        if filename == "setup.cfg":
-            config = configparser.ConfigParser()
-            config.read(filename)
-            return dict(config.items("qgis-plugin-ci"))
-
-        _, suffix = filename.rsplit(".", 1)
-
-        with open(filename) as f:
-            if suffix == "toml":
-                return toml.load(f)
-            elif suffix in {"yaml", "yml"}:
-                return yaml.safe_load(f)
-
-        raise configuration_not_found
-
-    if config_file:
-        config_dict = load_config(config_file)
-    else:
-        config_dict = explore_config()
-
-    return Parameters(config_dict)
 
 
 def convert_octets(octets: int) -> str:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ pyqt5ac>=1.2,<1.3
 python-slugify>=4.0,<8.1
 pyyaml>=5.4,<6.1
 transifex-python>=3.2,<4.0
+toml>=0.10.2

--- a/test/fixtures/.qgis-plugin-ci
+++ b/test/fixtures/.qgis-plugin-ci
@@ -1,0 +1,14 @@
+plugin_path: qgis_plugin_CI_testing
+github_organization_slug: opengisch
+project_slug: qgis-plugin-ci
+transifex_coordinator: geoninja
+transifex_organization: pytransifex
+translation_languages:
+  - fr
+  - it
+  - de
+create_date: 1985-07-21
+
+repository_url: https://github.com/opengisch/qgis-plugin-ci/
+
+#lrelease_path: /usr/local/opt/qt5/bin/lrelease

--- a/test/fixtures/pyproject.toml
+++ b/test/fixtures/pyproject.toml
@@ -1,0 +1,4 @@
+[qgis-plugin-ci]
+plugin_path = "qgis_plugin_CI_testing"
+github_organization_slug = "opengisch"
+project_slug = "qgis_plugin_ci_testing"

--- a/test/fixtures/setup.cfg
+++ b/test/fixtures/setup.cfg
@@ -1,0 +1,4 @@
+[qgis-plugin-ci]
+plugin_path = qgis_plugin_CI_testing
+github_organization_slug = opengisch
+project_slug = qgis_plugin_ci_testing

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -20,7 +20,7 @@ from qgispluginci.exceptions import GithubReleaseNotFound
 from qgispluginci.parameters import DASH_WARNING, Parameters
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
-from qgispluginci.utils import make_parameters, replace_in_file
+from qgispluginci.utils import replace_in_file
 
 # Tests
 from .utils import can_skip_test
@@ -31,10 +31,15 @@ RELEASE_VERSION_TEST = "0.1.2"
 
 class TestRelease(unittest.TestCase):
     def setUp(self):
-        self.setup_params = make_parameters("setup.cfg")
-        self.qgis_plugin_config_params = make_parameters(".qgis-plugin-ci")
-        self.pyproject_params = make_parameters("pyproject.toml")
-
+        self.setup_params = Parameters.make_from(
+            config_file=os.path.relpath("test/fixtures/setup.cfg")
+        )
+        self.qgis_plugin_config_params = Parameters.make_from(
+            config_file=os.path.relpath("test/fixtures/.qgis-plugin-ci")
+        )
+        self.pyproject_params = Parameters.make_from(
+            config_file=os.path.realpath("test/fixtures/pyproject.toml")
+        )
         self.tx_api_token = os.getenv("tx_api_token")
         self.github_token = os.getenv("github_token")
         self.repo = None
@@ -72,6 +77,7 @@ class TestRelease(unittest.TestCase):
         release(self.qgis_plugin_config_params, RELEASE_VERSION_TEST)
 
     def test_release_from_pyproject(self):
+        print(self.pyproject_params)
         release(self.pyproject_params, RELEASE_VERSION_TEST)
 
     @unittest.skipIf(can_skip_test(), "Missing tx_api_token")


### PR DESCRIPTION
_Adding support for pyproject.toml files_
- pyproject.toml are becoming the standard nowadays for packaging Python applications so I felt it would be nice to offer that
- did some DRY-cleaning, moving the logic initializing the argparse Parameters to a stand-alone top level function; it could be an instance method of Parameters too, it's easy to refactor from  one to the other
- added tests leveraging the two aforementioned changes
- reduced time complexity when collecting metadata
- sprinkled some type hints here and there.