### PR TITLE
Fixing missing accessor, DRY-cleaning, user-friendly config exploration

### DIFF
--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -124,7 +124,8 @@ class Parameters:
             elif os.path.isfile("pyproject.toml"):
                 # We read the pyproject.toml file
                 with open("pyproject.toml", encoding="utf8") as f:
-                    arg_dict = toml.load(f)
+                    contents = toml.load(f)
+                    arg_dict = contents["qgis-plugin-ci"]
             else:
                 config = configparser.ConfigParser()
                 config.read("setup.cfg")

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -32,13 +32,13 @@ RELEASE_VERSION_TEST = "0.1.2"
 class TestRelease(unittest.TestCase):
     def setUp(self):
         self.setup_params = Parameters.make_from(
-            config_file=os.path.relpath("test/fixtures/setup.cfg")
+            path_to_config_file=Path("test/fixtures/setup.cfg")
         )
         self.qgis_plugin_config_params = Parameters.make_from(
-            config_file=os.path.relpath("test/fixtures/.qgis-plugin-ci")
+            path_to_config_file=Path("test/fixtures/.qgis-plugin-ci")
         )
         self.pyproject_params = Parameters.make_from(
-            config_file=os.path.realpath("test/fixtures/pyproject.toml")
+            path_to_config_file=Path("test/fixtures/pyproject.toml")
         )
         self.tx_api_token = os.getenv("tx_api_token")
         self.github_token = os.getenv("github_token")


### PR DESCRIPTION
This PR:
1. fixes a bug caused by a missing __getitem__(), which should have been like https://github.com/opengisch/qgis-plugin-ci/blob/a73484f50999b0dd558a2753dc2ff3948bfb9d04/qgispluginci/parameters.py#L156; the bug nullified the support for `pyproject.toml`;
2. refactors Parameter creation so that it is DRY-er and makes it possible to define a valid config in any of the possible file formats/filenames supported _even if more than one are defined_ (previously, if the user's project contained multiple supported filenames/formats, Parameter creation would choke on the first file found invalid, even if another file was valid). 