### PR TITLE
Allow adding additional assets

### DIFF
--- a/docs/usage/cli_package.md
+++ b/docs/usage/cli_package.md
@@ -26,7 +26,8 @@ optional arguments:
                         changes made by qgis-plugin-ci.
   -d --disable-submodule-update
                         If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.
-
+  -a ASSET_PATH, --asset-path ASSET_PATH
+                        An additional asset path to add. Can be specified multiple times.
 ```
 
 ## Additional metadata

--- a/docs/usage/cli_release.md
+++ b/docs/usage/cli_release.md
@@ -37,6 +37,8 @@ options:
   --alternative-repo-url ALTERNATIVE_REPO_URL
                         The URL of the endpoint to publish the plugin (defaults to
                         plugins.qgis.org)
+  -a ASSET_PATH, --asset-path ASSET_PATH
+                        An additional asset path to add. Can be specified multiple times.
   --osgeo-username OSGEO_USERNAME
                         The Osgeo user name to publish the plugin.
   --osgeo-password OSGEO_PASSWORD

--- a/qgispluginci/cli.py
+++ b/qgispluginci/cli.py
@@ -65,6 +65,12 @@ def cli():
         action="store_true",
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",
     )
+    package_parser.add_argument(
+        "-a",
+        "--asset-path",
+        action="append",
+        help="An additional asset path to add. Can be specified multiple times.",
+    )
 
     # changelog
     changelog_parser = subparsers.add_parser(
@@ -112,6 +118,12 @@ def cli():
         "--disable-submodule-update",
         action="store_true",
         help="If omitted, a git submodule is updated. If specified, git submodules will not be updated/initialized before packaging.",
+    )
+    release_parser.add_argument(
+        "-a",
+        "--asset-path",
+        action="append",
+        help="An additional asset path to add. Can be specified multiple times.",
     )
     release_parser.add_argument(
         "--alternative-repo-url",
@@ -188,6 +200,7 @@ def cli():
             allow_uncommitted_changes=args.allow_uncommitted_changes,
             plugin_repo_url=args.plugin_repo_url,
             disable_submodule_update=args.disable_submodule_update,
+            asset_paths=args.asset_path,
         )
 
     # RELEASE
@@ -204,6 +217,7 @@ def cli():
             osgeo_password=args.osgeo_password,
             allow_uncommitted_changes=args.allow_uncommitted_changes,
             disable_submodule_update=args.disable_submodule_update,
+            asset_paths=args.asset_path,
         )
 
     # TRANSLATION PULL

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -229,9 +229,10 @@ def create_archive(
                 # https://stackoverflow.com/a/48462950/1548052
                 tt.add(file)
     # Add assets
-    with tarfile.open(top_tar_file, mode="a") as tt:
-        for asset_path in asset_paths:
-            tt.add(asset_path)
+    if len(asset_paths) > 0:
+        with tarfile.open(top_tar_file, mode="a") as tt:
+            for asset_path in asset_paths:
+                tt.add(asset_path)
 
     # converting to ZIP
     # why using TAR before? because it provides the prefix and makes things easier

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -10,6 +10,7 @@ import zipfile
 from glob import glob
 from pathlib import Path
 from tempfile import mkstemp
+from typing import List
 
 import git
 from github import Github, GithubException
@@ -54,6 +55,7 @@ def create_archive(
     is_prerelease: bool = False,
     raise_min_version: str = None,
     disable_submodule_update: bool = False,
+    asset_paths: List[str] = [],
 ):
     repo = git.Repo()
 
@@ -226,6 +228,10 @@ def create_archive(
                 logger.debug(f"\tAdding resource: {file}")
                 # https://stackoverflow.com/a/48462950/1548052
                 tt.add(file)
+    # Add assets
+    with tarfile.open(top_tar_file, mode="a") as tt:
+        for asset_path in asset_paths:
+            tt.add(asset_path)
 
     # converting to ZIP
     # why using TAR before? because it provides the prefix and makes things easier
@@ -477,6 +483,7 @@ def release(
     allow_uncommitted_changes: bool = False,
     plugin_repo_url: str = None,
     disable_submodule_update: bool = False,
+    asset_paths: List[str] = [],
 ):
     """
 
@@ -547,6 +554,7 @@ def release(
         allow_uncommitted_changes=allow_uncommitted_changes,
         is_prerelease=is_prerelease,
         disable_submodule_update=disable_submodule_update,
+        asset_paths=asset_paths,
     )
 
     # if pushing to QGIS repo and pre-release, create an extra package with qgisMinVersion to 3.14


### PR DESCRIPTION
Adds a new parameter `--asset-path` or `-a` followed by a path to an additional asset to be packaged/released.

```
qgis-plugin-ci package 1.0 --asset-path myplugin/some_dependency-1.0-py3-none-any.whl
```