### PR TITLE
Pass authentication as a header

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import base64
 import logging
 import os
 import re
@@ -433,11 +434,16 @@ def upload_plugin_to_osgeo(
         The plugin archive file path to be uploaded
     """
     if not server_url:
-        server_url = "plugins.qgis.org:443/plugins/RPC2/"
-    address = f"https://{username}:{password}@{server_url}"
+        server_url = "https://plugins.qgis.org:443/plugins/RPC2/"
+
+    encoded_auth_string = base64.b64encode(f"{username}:{password}".encode()).decode(
+        "utf-8"
+    )
 
     server = xmlrpc.client.ServerProxy(
-        address, verbose=(logger.getEffectiveLevel() <= 10)
+        server_url,
+        verbose=(logger.getEffectiveLevel() <= 10),
+        headers=[("Authorization", f"Basic {encoded_auth_string}")],
     )
 
     try:


### PR DESCRIPTION
Previously special characters in the username or password could lead to a crash during address parsing. This pull request addresses the issue by manually forming the Authorization header value, allowing for special characters.

An alternative approach would have been to quote all special characters from the username and password using urllib.parse.quote() and then utilizing the quoted values in the URI. However, the current approach was chosen over this alternative because it eliminates the need to modify the server_url if it is provided as a parameter. Additionally, this method avoids unnecessary quote-unquote steps.


Resolves #259