### PR TITLE
Fix previous commit about logging in transifex

### DIFF
--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -250,7 +250,7 @@ class Parameters:
         - the value of `release_version` matches no supported pattern.
         In any case, warn the user if the value of `release_version` doesn't match the semver pattern.
         """
-        if not hasattr(args, 'release_version') or not args.release_version:
+        if not hasattr(args, "release_version") or not args.release_version:
             return
 
         patterns = Parameters.get_release_version_patterns()

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -250,7 +250,7 @@ class Parameters:
         - the value of `release_version` matches no supported pattern.
         In any case, warn the user if the value of `release_version` doesn't match the semver pattern.
         """
-        if not args.release_version:
+        if not hasattr(args, 'release_version') or not args.release_version:
             return
 
         patterns = Parameters.get_release_version_patterns()

--- a/qgispluginci/translation.py
+++ b/qgispluginci/translation.py
@@ -139,7 +139,7 @@ class Translation:
         for lang in existing_langs:
             ts_file = f"{self.parameters.plugin_path}/i18n/{self.parameters.transifex_resource}_{lang}.ts"
             logger.debug(
-                f"Downloading translation file: {ts_file}, resource: {self.config.resource_slug}"
+                f"Downloading translation file: {ts_file}"
             )
             self.tx_client.get_translation(
                 language_code=lang,

--- a/qgispluginci/translation.py
+++ b/qgispluginci/translation.py
@@ -138,9 +138,7 @@ class Translation:
                 existing_langs.append(lang)
         for lang in existing_langs:
             ts_file = f"{self.parameters.plugin_path}/i18n/{self.parameters.transifex_resource}_{lang}.ts"
-            logger.debug(
-                f"Downloading translation file: {ts_file}"
-            )
+            logger.debug(f"Downloading translation file: {ts_file}")
             self.tx_client.get_translation(
                 language_code=lang,
                 path_to_output_file=ts_file,


### PR DESCRIPTION
Fix reported issue from @3nids about #258 

My IDE is indeed warning me today about this error...

Manually run, to check, I met another issue about `args` : 

```bash
➜ qgis-plugin-ci --verbose pull-translation ${TRANSIFEX_TOKEN}
2023-12-18 20:32:07||INFO||translation||27 languages found for resource '<Resource: o:3liz-1:p:lizmap-locales:r:lizmap_qgis_plugin>': (['bg', 'cs', 'de', 'el', 'es', 'es_AR', 'eu', 'fi', 'fr', 'gl', 'hu_HU', 'id', 'it', 'ja', 'nl', 'no', 'pl_PL', 'pt', 'pt_BR', 'ro', 'ru', 'sk', 'sl', 'sr@Cyrl', 'sv_SE', 'uk_UA', 'vi_VN'])
2023-12-18 20:32:07||DEBUG||translation||Downloading translation file: lizmap/i18n/lizmap_qgis_plugin_bg.ts
...
```

I think it's enough, we have the resource displayed once at the beginning, and then the filename