### PR TITLE
Fix incorrect subparser, missing exception guards (release 2.8.2)

### DIFF
--- a/qgispluginci/cli.py
+++ b/qgispluginci/cli.py
@@ -71,6 +71,11 @@ def cli():
         action="append",
         help="An additional asset path to add. Can be specified multiple times.",
     )
+    package_parser.add_argument(
+        "--no-validation",
+        action="store_true",
+        help="Turn off validation of `release version`",
+    )
 
     # changelog
     changelog_parser = subparsers.add_parser(
@@ -87,11 +92,6 @@ def cli():
     release_parser = subparsers.add_parser("release", help="release the plugin")
     release_parser.add_argument(
         "release_version", help="The version to be released (x.y.z)."
-    )
-    release_parser.add_argument(
-        "--no-validation",
-        action="store_true",
-        help="Turn off validation of `release version`",
     )
     release_parser.add_argument(
         "--release-tag",

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -146,7 +146,11 @@ class Parameters:
                 if path_to_file.is_file():
                     try:
                         return load_config(path_to_file, path_to_file.name)
-                    except ConfigurationNotFound:
+                    except (
+                        ConfigurationNotFound,
+                        configparser.NoSectionError,
+                        KeyError,
+                    ):
                         pass
             raise configuration_not_found
 

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -239,7 +239,7 @@ class TestRelease(unittest.TestCase):
         sub_parser = subparsers.add_parser("package")
         sub_parser.add_argument("release_version")
         sub_parser.add_argument("--no-validation", action="store_true")
-        args = parser.parse_args(["v1"])
+        args = parser.parse_args(["package", "v1"])
         with self.assertRaises(ValueError):
             Parameters.validate_args(args)
 
@@ -251,7 +251,7 @@ class TestRelease(unittest.TestCase):
         sub_parser = subparsers.add_parser("package")
         sub_parser.add_argument("release_version")
         sub_parser.add_argument("--no-validation", action="store_true")
-        args = parser.parse_args([".", "--no-validation"])
+        args = parser.parse_args(["package", "v1", "--no-validation"])
         Parameters.validate_args(args)
 
 

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -233,16 +233,24 @@ class TestRelease(unittest.TestCase):
 
     def test_release_version_validation_on(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument("release_version")
-        parser.add_argument("--no-validation", action="store_true")
+        subparsers = parser.add_subparsers(
+            title="commands", description="qgis-plugin-ci command", dest="command"
+        )
+        sub_parser = subparsers.add_parser("package")
+        sub_parser.add_argument("release_version")
+        sub_parser.add_argument("--no-validation", action="store_true")
         args = parser.parse_args(["v1"])
         with self.assertRaises(ValueError):
             Parameters.validate_args(args)
 
     def test_release_version_validation_off(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument("release_version")
-        parser.add_argument("--no-validation", action="store_true")
+        subparsers = parser.add_subparsers(
+            title="commands", description="qgis-plugin-ci command", dest="command"
+        )
+        sub_parser = subparsers.add_parser("package")
+        sub_parser.add_argument("release_version")
+        sub_parser.add_argument("--no-validation", action="store_true")
         args = parser.parse_args([".", "--no-validation"])
         Parameters.validate_args(args)
 


### PR DESCRIPTION
Was notified that CIs are choking on the `no_validation` flag. Here is the fix. This went unnoticed in tests as the tests don't use the particular parser/subparser structure as the code base.