### PR TITLE
parameters: Allow 'latest' as a valid release value

### DIFF
--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -244,6 +244,7 @@ class Parameters:
             "v3": r"^v\d+\.\d+\.\d+$",
             # See https://github.com/semver/semver/blob/master/semver.md#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
             "semver": r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+            "latest": r"^latest$",
         }
 
     @staticmethod

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -208,7 +208,15 @@ class TestRelease(unittest.TestCase):
         self.assertEqual(0, len(re.findall(r"commitSha1=\d+", str(data))))
 
     def test_release_version_valid_invalid(self):
-        valid_tags = ["v1.1.1", "v1.1", "1.0.1", "1.1", "1.0.0-alpha", "1.0.0-dev"]
+        valid_tags = [
+            "v1.1.1",
+            "v1.1",
+            "1.0.1",
+            "1.1",
+            "1.0.0-alpha",
+            "1.0.0-dev",
+            "latest",
+        ]
         invalid_tags = ["1", "v1", ".", ".1"]
         expected_valid_results = {
             "v1.1.1": ["v3"],
@@ -217,6 +225,7 @@ class TestRelease(unittest.TestCase):
             "1.1": ["simple"],
             "1.0.0-alpha": ["semver"],
             "1.0.0-dev": ["semver"],
+            "latest": ["latest"],
         }
         valid_results = {tag: [] for tag in valid_tags}
         patterns = Parameters.get_release_version_patterns()


### PR DESCRIPTION
This is a follow-up of 582278d11d94e1efb72acb0bbec0cd0b0dd3bcee which introduced support to check for correct release version patterns. This only allows semvar related values.
However, the `package` command uses the `latest` version by default. This means that the command `qgis-plugin-ci package` now fails because `latest` pattern is not allowed.

This issue is fixed by adding `^latest$` to the allowed patterns in version check.