### PR TITLE
fix plugin structure if the plugin directory is not top level

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -1,4 +1,6 @@
-# Settings
+# Configuration
+
+## Settings
 
 The plugin must have a configuration, located at the top directory; it can be either:
 
@@ -8,12 +10,11 @@ The plugin must have a configuration, located at the top directory; it can be ei
 
 In the configuration, you should at least provide the following configuration:
 
-- `plugin_path`, the folder where the source code is located
-
-Side note, the plugin path shouldn't have any dash character.
+- `plugin_path`, the folder where the source code is located under the git repository. See
 
 You can find a template `.qgis-plugin-ci` in this repository.
-You can read the docstring of the [Parameters module](/_apidoc/qgispluginci.parameters) to know parameters which are available in the file.
+You can read the docstring of the [Parameters module](/_apidoc/qgispluginci.parameters)
+to know parameters which are available in the file.
 
 ## Conventions
 

--- a/docs/configuration/plugin_path.md
+++ b/docs/configuration/plugin_path.md
@@ -1,0 +1,11 @@
+# Plugin source path
+
+The plugin path should be named in a distinctive form for the plugin
+as it will be used in QGIS for the plugin folder name.
+For instance, `my_super_transformer` for _My Super Transformer_ plugin.
+
+Also, [`use_project_slug_as_plugin_directory`](/_apidoc/qgispluginci.parameters) can be used to alter this behavior.
+If the source directory is not at the top level, the [`project_slug`](/_apidoc/qgispluginci.parameters)
+will automatically be used in any case.
+
+Side note, the plugin path shouldn't contain any dash character.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ caption: Configuration
 maxdepth: 1
 ---
 configuration/options
+configuration/plugin_path
 configuration/exclude
 configuration/submodules
 configuration/translation

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,16 +127,6 @@ GeoMapFish Locator
 VeriVD
 ^^^^^^
 
-* translated on Transifex
-* released on official repo
-:::
-
-:::{card}
-:link: https://github.com/VeriVD/qgis_VeriVD/
-
-VeriVD
-^^^^^^
-
 * released on custom repo as GitHub release
 :::
 

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -178,9 +178,11 @@ class Parameters:
         self.plugin_slug = slugify(self.plugin_name)
 
         # fix directory in zip file
-        self.use_project_slug_as_plugin_directory = definition.get("use_project_slug_as_plugin_directory", False)
+        self.use_project_slug_as_plugin_directory = definition.get(
+            "use_project_slug_as_plugin_directory", False
+        )
         # if not top level: force to use project slug
-        if self.plugin_path.count('/') > 0:
+        if self.plugin_path.count("/") > 0:
             self.plugin_zip_directory = self.plugin_slug
         # otherwise use setting
         elif self.use_project_slug_as_plugin_directory:

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -104,6 +104,9 @@ class Parameters:
     pylupdate5_path: str
         The path of pylupdate executable
 
+    use_project_slug_as_plugin_directory: bool
+        If True, the `project_slug` is used for the plugin directory name in the installation.
+        Defaults to False
 
     """
 
@@ -173,6 +176,20 @@ class Parameters:
         get_metadata = self.collect_metadata()
         self.plugin_name = get_metadata("name")
         self.plugin_slug = slugify(self.plugin_name)
+
+        # fix directory in zip file
+        self.use_project_slug_as_plugin_directory = definition.get("use_project_slug_as_plugin_directory", False)
+        # if not top level: force to use project slug
+        if self.plugin_path.count('/') > 0:
+            self.plugin_zip_directory = self.plugin_slug
+        # otherwise use setting
+        elif self.use_project_slug_as_plugin_directory:
+            self.plugin_zip_directory = self.plugin_slug
+        # we cannot force to use project_slug as it would be a breaking change for existing plugins
+        # as this would lead to have 2 versions of the plugin (1 with the old directory name, 1 with the old one)
+        else:
+            self.plugin_zip_directory = self.plugin_path
+
         self.project_slug = definition.get(
             "project_slug",
             os.environ.get("TRAVIS_REPO_SLUG", f".../{self.plugin_slug}").split("/")[1],

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -249,8 +249,13 @@ def create_archive(
                 fl = f.read()
                 fn = m.name
                 # Get permissions and add it to ZipInfo
-                st = os.stat(m.name)
-                info = zipfile.ZipInfo(fn)
+                st = os.stat(fn)
+
+                # fix directory structure if plugin path is not top level
+                # or if the plugin source directory is not distinctive (src, plugin, etc.)
+                # e.g. plugin/some_dir/metadata.txt => my_plugin/metadata.txt
+                fixed_path = fn.replace(parameters.plugin_path, parameters.plugin_zip_directory)
+                info = zipfile.ZipInfo(fixed_path)
 
                 # Using flags as defined in python zipfile module
                 # code : https://github.com/python/cpython/blob/b885b8f4be9c74ef1ce7923dbf055c31e7f47735/Lib/zipfile.py#L545

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -254,7 +254,9 @@ def create_archive(
                 # fix directory structure if plugin path is not top level
                 # or if the plugin source directory is not distinctive (src, plugin, etc.)
                 # e.g. plugin/some_dir/metadata.txt => my_plugin/metadata.txt
-                fixed_path = fn.replace(parameters.plugin_path, parameters.plugin_zip_directory)
+                fixed_path = fn.replace(
+                    parameters.plugin_path, parameters.plugin_zip_directory
+                )
                 info = zipfile.ZipInfo(fixed_path)
 
                 # Using flags as defined in python zipfile module


### PR DESCRIPTION
if your plugin source directory is not top level, this is causing issues in the zip structure as you have nested folders.
Another linked issue is if the plugin source is not equal to the plugin name, and it's not distinctive (such as src or plugin), this would link to conflicts between plugins.

This PR is fixing both scenarios.

