### PR TITLE
avoid doc building cancel

### DIFF
--- a/.github/workflows/docs_builder.yml
+++ b/.github/workflows/docs_builder.yml
@@ -25,7 +25,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
this would avoid canceling the workflow of a release in the rare case of a pull request being created during the process