### PR TITLE
drop raising minimum QGIS version to 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Both can be achieved in the same process.
 ## Pre-release and experimental
 
 In the case of a pre-release (either from the tag name according to [Semantic Versioning](https://semver.org/) or from the GitHub release), the plugin will be flagged as experimental.
-If pushed to the QGIS plugin repository, the QGIS minimum version will be raised to QGIS 3.14 (only 3.14 and above support testing of experimental versions).
 
 The tool will recognise any label use as a suffix to flag it as pre-release :
 

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -305,9 +305,7 @@ class Parameters:
         )
 
     @staticmethod
-    def archive_name(
-        plugin_name, release_version: str, experimental: bool = False
-    ) -> str:
+    def archive_name(plugin_name, release_version: str) -> str:
         """
         Returns the archive file name
         """
@@ -316,8 +314,7 @@ class Parameters:
         if "-" in plugin_name:
             logger.warning(DASH_WARNING)
 
-        experimental = "-experimental" if experimental else ""
-        return f"{plugin_name}{experimental}.{release_version}.zip"
+        return f"{plugin_name}.{release_version}.zip"
 
     def collect_metadata(self) -> Callable[[str, Optional[Any]], Any]:
         """

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -31,7 +31,6 @@ from qgispluginci.exceptions import (
     BuiltResourceInSources,
     GithubReleaseCouldNotUploadAsset,
     GithubReleaseNotFound,
-    MissingChangelog,
     UncommitedChanges,
 )
 from qgispluginci.parameters import Parameters
@@ -571,24 +570,6 @@ def release(
         asset_paths=asset_paths,
     )
 
-    # if pushing to QGIS repo and pre-release, create an extra package with qgisMinVersion to 3.14
-    # since only QGIS 3.14+ supports the beta/experimental plugins trial
-    experimental_archive_name = None
-    if osgeo_username is not None and is_prerelease:
-        experimental_archive_name = parameters.archive_name(
-            parameters.plugin_path, release_version, True
-        )
-        create_archive(
-            parameters,
-            release_version,
-            experimental_archive_name,
-            add_translations=tx_api_token is not None,
-            allow_uncommitted_changes=allow_uncommitted_changes,
-            is_prerelease=True,
-            raise_min_version="3.14",
-            disable_submodule_update=disable_submodule_update,
-        )
-
     if github_token is not None:
         upload_asset_to_github_release(
             parameters,
@@ -627,18 +608,9 @@ def release(
 
     if osgeo_username is not None:
         assert osgeo_password is not None
-        if is_prerelease:
-            assert experimental_archive_name is not None
-            upload_plugin_to_osgeo(
-                username=osgeo_username,
-                password=osgeo_password,
-                archive=experimental_archive_name,
-                server_url=alternative_repo_url,
-            )
-        else:
-            upload_plugin_to_osgeo(
-                username=osgeo_username,
-                password=osgeo_password,
-                archive=archive_name,
-                server_url=alternative_repo_url,
-            )
+        upload_plugin_to_osgeo(
+            username=osgeo_username,
+            password=osgeo_password,
+            archive=archive_name,
+            server_url=alternative_repo_url,
+        )

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -98,12 +98,8 @@ class TestRelease(unittest.TestCase):
         and also capital letters
         """
         self.assertEqual(
-            "my_plugin-experimental.0.0.0.zip",
-            Parameters.archive_name("my_plugin", "0.0.0", True),
-        )
-
-        self.assertEqual(
-            "My_Plugin.0.0.0.zip", Parameters.archive_name("My_Plugin", "0.0.0", False)
+            "my_plugin.0.0.0.zip",
+            Parameters.archive_name("my_plugin", "0.0.0"),
         )
 
         with self.assertLogs(


### PR DESCRIPTION
for experimental releases and avoid creating two archives

There is an issue in the current code with experimental plugins: if you have a QGIS minimum version to 3.28 and create an experimental plugin, the min version would be 3.14.

Rather than fixing this, I'd rather drop the code, since 3.14 is almost 4 years old.

Another unseen bug is that asset_paths were not given in the experimental archive creation.

So, a small cleanup in the end.