### PR TITLE
use underscore separators for plugin slug (zip folder)

### DIFF
--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -175,7 +175,7 @@ class Parameters:
 
         get_metadata = self.collect_metadata()
         self.plugin_name = get_metadata("name")
-        self.plugin_slug = slugify(self.plugin_name, separator='_')
+        self.plugin_slug = slugify(self.plugin_name, separator="_")
 
         # fix directory in zip file
         self.use_project_slug_as_plugin_directory = definition.get(

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -175,7 +175,7 @@ class Parameters:
 
         get_metadata = self.collect_metadata()
         self.plugin_name = get_metadata("name")
-        self.plugin_slug = slugify(self.plugin_name)
+        self.plugin_slug = slugify(self.plugin_name, separator='_')
 
         # fix directory in zip file
         self.use_project_slug_as_plugin_directory = definition.get(


### PR DESCRIPTION
since we don't want dashes in folder names