### PR TITLE
Fix use of the changelog CLI without configuration file

### DIFF
--- a/qgispluginci/cli.py
+++ b/qgispluginci/cli.py
@@ -84,8 +84,10 @@ def cli():
     )
     changelog_parser.add_argument(
         "release_version",
-        help="The version to be released. If nothing is speficied, \
-                                      the latest version specified into the changelog is used.",
+        help=(
+            "The version to be released. If nothing is specified, the latest version specified into the changelog is "
+            "used."
+        ),
         default="latest",
     )
 
@@ -182,11 +184,12 @@ def cli():
 
     exit_val = 0
 
-    # Initialize Parameters
-    parameters = Parameters.make_from(args=args)
     # CHANGELOG
     if args.command == "changelog":
         try:
+            # Initialize Parameters
+            # Configuration file is optional at this stage
+            parameters = Parameters.make_from(args=args, optional_configuration=True)
             c = ChangelogParser(
                 changelog_path=parameters.changelog_path,
             )
@@ -197,6 +200,10 @@ def cli():
             logger.error("Something went wrong reading the changelog.", exc_info=exc)
 
         return exit_val
+
+    # Initialize Parameters
+    # Configuration file is now required
+    parameters = Parameters.make_from(args=args)
 
     # PACKAGE
     if args.command == "package":

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -112,7 +112,11 @@ class Parameters:
 
     @classmethod
     def make_from(
-        cls, *, args: Optional[Any] = None, path_to_config_file: Optional[Path] = None
+        cls,
+        *,
+        args: Optional[Any] = None,
+        path_to_config_file: Optional[Path] = None,
+        optional_configuration: bool = False,
     ) -> "Parameters":
         """
         Instantiate from a config file or by exploring the filesystem
@@ -157,6 +161,9 @@ class Parameters:
                         pass
             raise configuration_not_found
 
+        if optional_configuration and not path_to_config_file:
+            return cls({})
+
         if path_to_config_file:
             file_name = path_to_config_file.name
 
@@ -172,6 +179,11 @@ class Parameters:
 
     def __init__(self, definition: Dict[str, Any]):
         self.plugin_path = definition.get("plugin_path")
+        self.changelog_path = definition.get("changelog_path", "CHANGELOG.md")
+
+        if not self.plugin_path:
+            # This tool can be used outside of a QGIS plugin to read a changelog file
+            return
 
         get_metadata = self.collect_metadata()
         self.plugin_name = get_metadata("name")
@@ -230,13 +242,8 @@ class Parameters:
         self.changelog_number_of_entries = definition.get(
             "changelog_number_of_entries", 3
         )
-        self.changelog_path = definition.get("changelog_path", "CHANGELOG.md")
 
         # read from metadata
-        if not self.plugin_path:
-            # This tool can be used outside of a QGIS plugin to read a changelog file
-            return
-
         self.author = get_metadata("author", "")
         self.description = get_metadata("description")
         self.qgis_minimum_version = get_metadata("qgisMinimumVersion")

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,0 +1,16 @@
+#! /usr/bin/env python
+
+# standard
+import unittest
+
+# Project
+from qgispluginci.parameters import Parameters
+
+
+class TestParameters(unittest.TestCase):
+    def test_changelog_parameters(self):
+        """Test parameters for changelog command."""
+        # For the changelog command, the configuration file is optional.
+        parameters = Parameters.make_from(args={}, optional_configuration=True)
+        self.assertEqual("CHANGELOG.md", parameters.changelog_path)
+        self.assertIsNone(parameters.plugin_path)


### PR DESCRIPTION
The changelog command could be used before without a configuration file.

A previous refactoring has broken this feature. I wrote a quick test, but not covering the CLI part

Can I make a release as well after ?
