### PR TITLE
do not enable transaction if TX token is an empty string

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -542,7 +542,7 @@ def release(
 
     release_tag = release_tag or release_version
 
-    if tx_api_token is not None:
+    if tx_api_token:
         tr = Translation(parameters, create_project=False, tx_api_token=tx_api_token)
         tr.pull()
         tr.compile_strings()


### PR DESCRIPTION
this would avoid complexity to handle lack on secrets (in PR from forks where secret is not available