### PR TITLE
fine tune test skipping

### DIFF
--- a/test/test_release.py
+++ b/test/test_release.py
@@ -25,7 +25,7 @@ from qgispluginci.translation import Translation
 from qgispluginci.utils import replace_in_file
 
 # Tests
-from .utils import can_skip_test
+from .utils import can_skip_test_github
 
 # If changed, also update CHANGELOG.md
 RELEASE_VERSION_TEST = "0.1.2"
@@ -89,7 +89,7 @@ class TestRelease(unittest.TestCase):
             tx_api_token="",
         )
 
-    @unittest.skipIf(can_skip_test(), "Missing tx_api_token")
+    @unittest.skipIf(can_skip_test_github(), "Missing tx_api_token")
     def test_release_with_transifex(self):
         Translation(self.qgis_plugin_config_params, tx_api_token=self.tx_api_token)
         release(
@@ -118,7 +118,7 @@ class TestRelease(unittest.TestCase):
         )  # check that there is only one log message
         self.assertEqual(captured.records[0].getMessage(), DASH_WARNING)
 
-    @unittest.skipIf(can_skip_test(), "Missing github_token")
+    @unittest.skipIf(can_skip_test_github(), "Missing github_token")
     def test_release_upload_github(self):
         release(
             self.qgis_plugin_config_params,

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -13,7 +13,7 @@ from qgispluginci.parameters import Parameters
 from qgispluginci.translation import Translation
 
 # Tests
-from .utils import can_skip_test
+from .utils import can_skip_test_transifex
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 unittest.TestLoader.sortTestMethodsUsing = None
 
 
-@unittest.skipIf(can_skip_test(), "Missing tx_api_token")
+@unittest.skipIf(can_skip_test_transifex(), "Missing tx_api_token")
 class TestTranslation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,16 +1,31 @@
 import os
 
 
-def can_skip_test():
-    """Check when a test can run."""
+def can_skip_test_github():
+    """Check when the Transifex test can run."""
     is_ci = os.getenv("CI") == "true"
     is_main_repo = os.getenv("GITHUB_REPOSITORY") == "opengisch/qgis-plugin-ci"
+
     if is_ci and is_main_repo:
+        return False
+
+    if not os.getenv("github_token"):
+        return True
+
+    return False
+
+
+def can_skip_test_transifex():
+    """Check when the Transifex test can run."""
+    is_ci = os.getenv("CI") == "true"
+    is_main_repo = os.getenv("GITHUB_REPOSITORY") == "opengisch/qgis-plugin-ci"
+    is_dependabot = os.getenv("GITHUB_ACTOR") == "dependabot[bot]"
+
+    if is_ci and is_main_repo and not is_dependabot:
         # Always run the test on CI
         return False
 
-    if not os.getenv("tx_api_token") or not os.getenv("github_token"):
-        # On local, the token must be set
+    if not os.getenv("tx_api_token"):
         return True
 
     return False


### PR DESCRIPTION
to solve dependabots tests

I think that the Github tests can be run for dependabot but not the Transifex ones.
We might need to set permissisons explicitly in the yml `contents: write` (see https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/) but let's test and see if it's required.