### PR TITLE
If LICENSE is missing from the plugin path but available in the parent path when packaging, include that

### DIFF
--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -199,7 +199,7 @@ def create_archive(
     if not Path(f"{parameters.plugin_path}/LICENSE").is_file():
         parent_license = Path(f"{parameters.plugin_path}/../LICENSE")
         if parent_license.is_file():
-            shutil.copy(str(parent_license.resolve()), f"{parameters.plugin_path}/LICENSE")
+            shutil.copy(parent_license, f"{parameters.plugin_path}/LICENSE")
             parent_folder_license_copied = True
             with tarfile.open(top_tar_file, mode="a") as tt:
                 tt.add(f"{parameters.plugin_path}/LICENSE")
@@ -277,8 +277,8 @@ def create_archive(
                 zf.writestr(info, fl)
 
     if parent_folder_license_copied:
-        os.remove(f"{parameters.plugin_path}/LICENSE")
-    
+        Path(f"{parameters.plugin_path}/LICENSE").unlink()
+
     logger.debug("-" * 40)
     logger.debug(f"Files in ZIP archive ({archive_name}):")
     with zipfile.ZipFile(file=archive_name, mode="r") as zf:

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -16,6 +16,9 @@ from zipfile import ZipFile
 import yaml
 from github import Github, GithubException
 
+# Tests
+from utils import can_skip_test_github
+
 # Project
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import GithubReleaseNotFound
@@ -23,9 +26,6 @@ from qgispluginci.parameters import DASH_WARNING, Parameters
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
 from qgispluginci.utils import replace_in_file
-
-# Tests
-from .utils import can_skip_test_github
 
 # If changed, also update CHANGELOG.md
 RELEASE_VERSION_TEST = "0.1.2"
@@ -196,12 +196,20 @@ class TestRelease(unittest.TestCase):
         # open archive and compare
         with ZipFile(archive_name, "r") as zip_file:
             data = zip_file.read(f"{parameters.plugin_path}/metadata.txt")
+            license_data = zip_file.read(f"{parameters.plugin_path}/LICENSE")
 
         # Changelog
         self.assertGreater(
             data.find(bytes(changelog_lastitems, "utf8")),
             0,
             f"changelog detection failed in release: {data}",
+        )
+
+        # License
+        self.assertGreater(
+            license_data.find(bytes("GNU GENERAL PUBLIC LICENSE", "utf8")),
+            0,
+            "license file content mismatch",
         )
 
         # Commit number


### PR DESCRIPTION
@m-kuhn , @suricactus , as discussed to fix qfieldsync releases.