### PR TITLE
 GH Action - Run dependabot only every 3 months

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   - package-ecosystem: pip
     directory: "/requirements"
     schedule:
-      interval: monthly
-      time: "04:00"
-      timezone: Europe/Paris
+      interval: "cron"
+      cronjob: "0 6 5 */3 *"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "cron"
+      cronjob: "0 6 5 */3 *"


### PR DESCRIPTION
Dependabot is "verbose" with all this "small PR" and in the commit history.

Anything against running it every 3 months ? (or even 4, 6 months?)