### PR TITLE
Remove deprecated dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,14 +5,20 @@ Configuration for project documentation using Sphinx.
 """
 
 # standard
+import sys
 from datetime import date, datetime
 from importlib.metadata import version
 from os import environ, path
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 __version__ = version("qgis-plugin-ci")
-pyproject = toml.load("../pyproject.toml")
+
+with open("../pyproject.toml", "rb") as f:
+    pyproject = tomllib.load(f)
 
 # -- Build environment -----------------------------------------------------
 on_rtd = environ.get("READTHEDOCS", None) == "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ packages = ["qgispluginci", "qgispluginci.translation_clients"]
 [tool.setuptools-git-versioning]
 enabled = true
 
-
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"], content-type = "text/markdown"}
 dependencies = {file = ["requirements/base.txt"]}

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -21,7 +21,13 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-import toml
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
 import yaml
 
 # 3rd party
@@ -138,14 +144,15 @@ class Parameters:
                 config.read(path_to_config_file)
                 arg_dict = dict(config.items("qgis-plugin-ci"))
             else:
-                with open(path_to_config_file) as fh:
-                    if file_name == ".qgis-plugin-ci":
+                if file_name == ".qgis-plugin-ci":
+                    with open(path_to_config_file) as fh:
                         arg_dict = yaml.safe_load(fh)
-                    elif file_name == "pyproject.toml":
-                        contents = toml.load(fh)
+                elif file_name == "pyproject.toml":
+                    with open(path_to_config_file, "rb") as fh:
+                        contents = tomllib.load(fh)
                         arg_dict = contents["tool"]["qgis-plugin-ci"]
-                    else:
-                        raise configuration_not_found
+                else:
+                    raise configuration_not_found
             return arg_dict
 
         def explore_config() -> dict[str, Any]:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,4 +9,4 @@ python-slugify>=4.0,<8.1
 pyyaml>=5.4,<6.1
 six>=1.16.0
 transifex-python>=3.2,<4.0
-toml>=0.10.2
+tomli >= 2.2; python_full_version < '3.11'

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -6,4 +6,4 @@ sphinx-autobuild>=2024
 sphinx-copybutton>=0.5
 sphinx-design>=0.6.0
 sphinx-sitemap>=2.4
-toml>=0.10.2
+tomli >= 2.2; python_full_version < '3.11'


### PR DESCRIPTION
Fix #338

* ~~Make `python-transifex an optional dependency` (partial fix for #323~~
* Replace `toml` with `tomllib` for Python >= 3.11,  tomli for Python < 3.11 