### PR TITLE
improve(repository): wrap with CDATA same fields as official repository

### DIFF
--- a/qgispluginci/plugins.xml.template
+++ b/qgispluginci/plugins.xml.template
@@ -1,21 +1,24 @@
 <?xml version = '1.0' encoding = 'UTF-8'?>
 <plugins>
     <pyqgis_plugin name="__PLUGIN_NAME__" version="__RELEASE_VERSION__">
-        <description><![CDATA[__DESCRIPTION__]]></description>
-        <version>__RELEASE_VERSION__</version>
-        <qgis_minimum_version>__QGIS_MIN_VERSION__</qgis_minimum_version>
-        <homepage>__HOMEPAGE__</homepage>
-        <file_name>__PLUGINZIP__</file_name>
-        <icon>__ICON__</icon>
-        <author_name>__AUTHOR__</author_name>
-        <download_url>__DOWNLOAD_URL__</download_url>
-        <uploaded_by>__OSGEO_USERNAME__</uploaded_by>
+        <!-- <about><![CDATA[__ABOUT__]]></about> -->
+        <author_name><![CDATA[__AUTHOR__]]></author_name>
         <create_date>__CREATE_DATE__</create_date>
-        <update_date>__RELEASE_DATE__</update_date>
-        <experimental>__EXPERIMENTAL__</experimental>
         <deprecated>__DEPRECATED__</deprecated>
-        <tracker>__ISSUE_TRACKER__</tracker>
-        <repository>__REPO_URL__</repository>
-        <tags>__TAGS__</tags>
+        <description><![CDATA[__DESCRIPTION__]]></description>
+        <download_url>__DOWNLOAD_URL__</download_url>
+        <experimental>__EXPERIMENTAL__</experimental>
+        <file_name>__PLUGINZIP__</file_name>
+        <homepage><![CDATA[__HOMEPAGE__]]></homepage>
+        <icon>__ICON__</icon>
+        <repository><![CDATA[__REPO_URL__]]></repository>
+        <!-- <qgis_maximum_version>__QGIS_MAX_VERSION__</qgis_maximum_version> -->
+        <qgis_minimum_version>__QGIS_MIN_VERSION__</qgis_minimum_version>
+        <!-- <server>__SERVER__</server> -->
+        <tags><![CDATA[__TAGS__]]></tags>
+        <tracker><![CDATA[__ISSUE_TRACKER__]]></tracker>
+        <update_date>__RELEASE_DATE__</update_date>
+        <uploaded_by><![CDATA[__OSGEO_USERNAME__]]></uploaded_by>
+        <version>__RELEASE_VERSION__</version>
     </pyqgis_plugin>
 </plugins>

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -403,31 +403,31 @@ def create_plugin_repo(
     archive: str,
     osgeo_username: str,
     is_prerelease: bool = False,
-    plugin_repo_url: str = None,
+    plugin_repo_url: str | None = None,
 ) -> str:
     """
     Creates the plugin repo as an XML file
     """
     replace_dict = {
-        "__RELEASE_VERSION__": release_version,
-        "__RELEASE_TAG__": release_tag or release_version,
-        "__PLUGIN_NAME__": parameters.plugin_name,
-        "__RELEASE_DATE__": datetime.date.today().strftime("%Y-%m-%d"),
-        "__CREATE_DATE__": parameters.create_date.strftime("%Y-%m-%d"),
-        "__ORG__": parameters.github_organization_slug,
-        "__REPO__": parameters.project_slug,
-        "__PLUGINZIP__": archive,
-        "__OSGEO_USERNAME__": osgeo_username or parameters.author,
-        "__DEPRECATED__": str(parameters.deprecated),
-        "__EXPERIMENTAL__": str(is_prerelease or parameters.experimental),
-        "__TAGS__": parameters.tags,
-        "__ICON__": parameters.icon,
         "__AUTHOR__": parameters.author,
-        "__QGIS_MIN_VERSION__": parameters.qgis_minimum_version,
+        "__CREATE_DATE__": parameters.create_date.strftime("%Y-%m-%d"),
+        "__DEPRECATED__": str(parameters.deprecated),
         "__DESCRIPTION__": parameters.description,
-        "__ISSUE_TRACKER__": parameters.issue_tracker,
+        "__EXPERIMENTAL__": str(is_prerelease or parameters.experimental),
         "__HOMEPAGE__": parameters.homepage,
+        "__ICON__": parameters.icon,
+        "__ISSUE_TRACKER__": parameters.issue_tracker,
+        "__ORG__": parameters.github_organization_slug,
+        "__OSGEO_USERNAME__": osgeo_username or parameters.author,
+        "__PLUGIN_NAME__": parameters.plugin_name,
+        "__PLUGINZIP__": archive,
+        "__RELEASE_DATE__": datetime.date.today().strftime("%Y-%m-%d"),
+        "__RELEASE_TAG__": release_tag or release_version,
+        "__RELEASE_VERSION__": release_version,
+        "__REPO__": parameters.project_slug,
         "__REPO_URL__": parameters.repository_url,
+        "__QGIS_MIN_VERSION__": parameters.qgis_minimum_version,
+        "__TAGS__": parameters.tags,
     }
     if not plugin_repo_url:
         orgs = replace_dict["__ORG__"]

--- a/test/plugins.xml.expected
+++ b/test/plugins.xml.expected
@@ -1,21 +1,24 @@
 <?xml version = '1.0' encoding = 'UTF-8'?>
 <plugins>
     <pyqgis_plugin name="QGIS Plugin CI Testing" version="0.1.2">
-        <description><![CDATA[This is a testing plugin for QGIS Plugin CI]]></description>
-        <version>0.1.2</version>
-        <qgis_minimum_version>3.2</qgis_minimum_version>
-        <homepage>https://github.com/opengisch/qgis-plugin-ci</homepage>
-        <file_name>qgis_plugin_CI_testing.0.1.2.zip</file_name>
-        <icon>icons/opengisch.png</icon>
-        <author_name>Denis Rouzaud</author_name>
-        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_CI_testing.0.1.2.zip</download_url>
-        <uploaded_by>Denis Rouzaud</uploaded_by>
+        <!-- <about><![CDATA[__ABOUT__]]></about> -->
+        <author_name><![CDATA[Denis Rouzaud]]></author_name>
         <create_date>1985-07-21</create_date>
-        <update_date>__TODAY__</update_date>
-        <experimental>True</experimental>
         <deprecated>False</deprecated>
-        <tracker>https://github.com/opengisch/qgis-plugin-ci/issues</tracker>
-        <repository>https://github.com/opengisch/qgis-plugin-ci</repository>
-        <tags></tags>
+        <description><![CDATA[This is a testing plugin for QGIS Plugin CI]]></description>
+        <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_CI_testing.0.1.2.zip</download_url>
+        <experimental>True</experimental>
+        <file_name>qgis_plugin_CI_testing.0.1.2.zip</file_name>
+        <homepage><![CDATA[https://github.com/opengisch/qgis-plugin-ci]]></homepage>
+        <icon>icons/opengisch.png</icon>
+        <repository><![CDATA[https://github.com/opengisch/qgis-plugin-ci]]></repository>
+        <!-- <qgis_maximum_version>__QGIS_MAX_VERSION__</qgis_maximum_version> -->
+        <qgis_minimum_version>3.2</qgis_minimum_version>
+        <!-- <server>__SERVER__</server> -->
+        <tags><![CDATA[]]></tags>
+        <tracker><![CDATA[https://github.com/opengisch/qgis-plugin-ci/issues]]></tracker>
+        <update_date>__TODAY__</update_date>
+        <uploaded_by><![CDATA[Denis Rouzaud]]></uploaded_by>
+        <version>0.1.2</version>
     </pyqgis_plugin>
 </plugins>


### PR DESCRIPTION
For now, I commented the missing fields `about`, `server` and `qgis_maximum_version` to remember to fill them later.  
I also order attributes in template and in code.

Related to #377

----

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->