### PR TITLE
Feature: make create_date a configurable timezoned datetime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directory: "/requirements"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "0 6 5 */3 *"

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ qgis_plugin_CI_testing/resources_rc.py
 .idea
 .DS_Store
 .venv
-.vscode/settings.json
+.vscode/
 dev_precommit_black.log
 
 htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ htmlcov
 junit
 .coverage
 coverage.xml
+plugins.xml

--- a/.qgis-plugin-ci
+++ b/.qgis-plugin-ci
@@ -8,6 +8,7 @@ translation_languages:
   - it
   - de
 create_date: 1985-07-21
+timezone: Europe/Paris
 
 repository_url: https://github.com/opengisch/qgis-plugin-ci/
 

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -13,23 +13,27 @@ In the configuration, you should at least provide the following configuration:
 - `plugin_path`, the folder where the source code is located under the git repository. See
 
 You can find a template `.qgis-plugin-ci` in this repository.
-You can read the docstring of the [Parameters module](/_apidoc/qgispluginci.parameters)
+You can read the docstring of the [Parameters module](../_apidoc/qgispluginci.parameters)
 to know parameters which are available in the file.
 
 ## Conventions
 
 QGIS-Plugin-CI is best served if you use these two conventions :
 
-* [Semantic versioning](https://semver.org/)
-* [Keep A Changelog](https://keepachangelog.com)
+- [Semantic versioning](https://semver.org/)
+- [Keep A Changelog](https://keepachangelog.com)
 
 ## Options
 
 | Name | Required | Description | Example |
 | :--- | :------: | :---------- | :------ |
-| `github_organization_slug` | no | The *organization* slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).<br/>Not required when running on Travis since deduced from `$TRAVIS_REPO_SLUG`environment variable. |  |
+| `create_date` | no | Plugin creation date. Used as `create_date` attribute in the custom `plugins.xml` repository. Defaults to build timestamp. | `1985-07-21` |
+| `github_organization_slug` | no | The *organization* slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).<br/>Not required when running on Travis since deduced from `$TRAVIS_REPO_SLUG`environment variable. | `opengisch` |
 | `plugin_path` | **yes** | The folder where the source code is located. Shouldn't have any dash character. Defaults to: `slugify(plugin_name)`. | qgis_plugin_CI_testing |
-| `project_slug` | no | The *project* slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).<br/>Not required when running on Travis since deduced from `$TRAVIS_REPO_SLUG`environment variable. |  |
+| `project_slug` | no | The *project* slug on SCM host (e.g. Github) and translation platform (e.g. Transifex).<br/>Not required when running on Travis since deduced from `$TRAVIS_REPO_SLUG`environment variable. | `qgis-plugin-ci` |
+| `timezone` | no | The timezone for the plugin creation date. Defaults to: `UTC`. | `Europe/Paris` |
+
+----
 
 ## Examples
 
@@ -49,6 +53,7 @@ plugin_path = QuickOSM
 github_organization_slug = 3liz
 project_slug = QuickOSM
 ```
+
 ### Using TOML file `pyproject.toml`
 
 ```toml

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -8,7 +8,7 @@ To build it:
 
 ```bash
 # install additional dependencies
-python -m pip install -U -r requirements/documentation.txt
+python -m pip install -U -e .[doc]
 # build it
 sphinx-build -b html docs docs/_build/html
 ```

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -8,13 +8,9 @@ Typically on Ubuntu:
 # create virtual environment linking to system packages (for pyqgis)
 python3 -m venv .venv
 
-# bump dependencies inside venv
-python -m pip install -U pip setuptools wheel
-python -m pip install -U -r requirements.txt
+# install project as editable with dev dependencies
+python -m pip install -U -e .[dev  ]
 
 # install git hooks
 pre-commit install
-
-# install project as editable
-python -m pip install -e .
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,5 +1,7 @@
 # Tests
 
+Install [development dependencies](./environment.md) and run tests to check that everything is working as expected.
+
 ## System requirements
 
 ```bash

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -8,16 +8,15 @@ Parameters management.
 # ########## Libraries #############
 # ##################################
 
+# standard library
 import configparser
-import datetime
 import logging
 import os
 import re
 import sys
-
-# standard library
 from argparse import Namespace
 from collections.abc import Callable, Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +31,9 @@ import yaml
 # 3rd party
 from slugify import slugify
 
+# package
 from qgispluginci.exceptions import ConfigurationNotFound
+from qgispluginci.utils import set_datetime_zoneinfo
 
 
 # ############################################################################
@@ -96,7 +97,7 @@ class Parameters:
         Number of changelog entries to add in the metdata.txt
         Defaults to 3
 
-    create_date: datetime.date
+    create_date: datetime.datetime
         The date of creation of the plugin.
         The would be used in the custom repository XML.
         Format: YYYY-MM-DD
@@ -227,9 +228,11 @@ class Parameters:
         self.transifex_resource = definition.get(
             "transifex_resource", self.project_slug
         )
-        self.create_date = datetime.datetime.strptime(
-            str(definition.get("create_date", datetime.date.today())), "%Y-%m-%d"
+        self.create_datetime: datetime = set_datetime_zoneinfo(
+            input_datetime=definition.get("create_date", datetime.now(timezone.utc)),
+            config_timezone=definition.get("timezone", "UTC"),
         )
+
         self.lrelease_path = definition.get("lrelease_path", "lrelease")
         self.pylupdate5_path = definition.get("pylupdate5_path", "pylupdate5")
         changelog_include = definition.get("changelog_include", True)

--- a/qgispluginci/parameters.py
+++ b/qgispluginci/parameters.py
@@ -97,7 +97,7 @@ class Parameters:
         Number of changelog entries to add in the metdata.txt
         Defaults to 3
 
-    create_date: datetime.datetime
+    create_datetime: datetime.datetime
         The date of creation of the plugin.
         The would be used in the custom repository XML.
         Format: YYYY-MM-DD
@@ -107,6 +107,9 @@ class Parameters:
 
     pylupdate5_path: str
         The path of pylupdate executable
+
+    timezone: str
+        The timezone for the plugin creation date. Defaults to: `UTC`.
 
     use_project_slug_as_plugin_directory: bool
         If True, the `project_slug` is used for the plugin directory name in the installation.
@@ -228,9 +231,11 @@ class Parameters:
         self.transifex_resource = definition.get(
             "transifex_resource", self.project_slug
         )
+
+        self.timezone = definition.get("timezone", "UTC")
         self.create_datetime: datetime = set_datetime_zoneinfo(
             input_datetime=definition.get("create_date", datetime.now(timezone.utc)),
-            config_timezone=definition.get("timezone", "UTC"),
+            config_timezone=self.timezone,
         )
 
         self.lrelease_path = definition.get("lrelease_path", "lrelease")

--- a/qgispluginci/release.py
+++ b/qgispluginci/release.py
@@ -2,7 +2,6 @@
 
 # standard
 import base64
-import datetime
 import importlib.resources as importlib_resources
 import logging
 import os
@@ -12,6 +11,7 @@ import sys
 import tarfile
 import xmlrpc.client
 import zipfile
+from datetime import date, datetime, timezone
 from glob import glob
 from pathlib import Path
 from tempfile import mkstemp
@@ -135,9 +135,7 @@ def create_archive(
     )
 
     # Date/time in UTC
-    date_time = datetime.datetime.now(datetime.timezone.utc).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
+    date_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     replace_in_file(
         f"{parameters.plugin_path}/metadata.txt",
         r"^dateTime=.*$",
@@ -411,7 +409,7 @@ def create_plugin_repo(
     replace_dict = {
         "__ABOUT__": parameters.about,
         "__AUTHOR__": parameters.author,
-        "__CREATE_DATE__": parameters.create_date.strftime("%Y-%m-%d"),
+        "__CREATE_DATE__": parameters.create_datetime.isoformat(),
         "__DEPRECATED__": str(parameters.deprecated),
         "__DESCRIPTION__": parameters.description,
         "__EXPERIMENTAL__": str(is_prerelease or parameters.experimental),
@@ -422,7 +420,7 @@ def create_plugin_repo(
         "__OSGEO_USERNAME__": osgeo_username or parameters.author,
         "__PLUGIN_NAME__": parameters.plugin_name,
         "__PLUGINZIP__": archive,
-        "__RELEASE_DATE__": datetime.date.today().strftime("%Y-%m-%d"),
+        "__RELEASE_DATE__": date.today().strftime("%Y-%m-%d"),
         "__RELEASE_TAG__": release_tag or release_version,
         "__RELEASE_VERSION__": release_version,
         "__REPO__": parameters.project_slug,

--- a/qgispluginci/utils.py
+++ b/qgispluginci/utils.py
@@ -1,8 +1,14 @@
+#! python3
+
+# standard library
 import logging
 import os
 import re
+from datetime import date, datetime, timezone
 from math import floor, log as math_log, pow as math_pow
+from zoneinfo import ZoneInfo
 
+# package
 from qgispluginci.version_note import VersionNote
 
 
@@ -77,3 +83,38 @@ def parse_tag(version_tag: str) -> VersionNote | None:
             return VersionNote(major=items[0], minor=items[1], patch=items[2])
     except IndexError:
         return VersionNote()
+
+
+def set_datetime_zoneinfo(
+    input_datetime: date | datetime, config_timezone: str = "UTC"
+) -> datetime:
+    """Apply timezone to a naive datetime or date.
+
+    Args:
+        input_datetime (date | datetime): offset-naive datetime
+        config_timezone (str, optional): name of timezone as registered in IANA
+            database. Defaults to "UTC". Example : Europe/Paris.
+
+    Returns:
+        datetime: offset-aware datetime
+    """
+    if isinstance(input_datetime, date):
+        input_datetime = datetime.combine(date=input_datetime, time=datetime.min.time())
+        logger.debug(
+            f"Input is a date, converted to datetime with time set to 00:00:00: {input_datetime}"
+        )
+
+    if input_datetime.tzinfo:
+        logger.debug(
+            f"Input datetime already has timezone info: {input_datetime.tzinfo}, no conversion applied."
+        )
+        return input_datetime
+    elif not config_timezone:
+        logger.debug("No timezone provided in config, applying UTC timezone.")
+        return input_datetime.replace(tzinfo=timezone.utc)
+    else:
+        config_tz = ZoneInfo(config_timezone)
+        logger.debug(
+            f"Applying timezone from config: {config_timezone} to input datetime."
+        )
+        return input_datetime.replace(tzinfo=config_tz)

--- a/test/fixtures/.qgis-plugin-ci
+++ b/test/fixtures/.qgis-plugin-ci
@@ -8,6 +8,7 @@ translation_languages:
   - it
   - de
 create_date: 1985-07-21
+timezone: Europe/Paris
 
 repository_url: https://github.com/opengisch/qgis-plugin-ci/
 

--- a/test/plugins.xml.expected
+++ b/test/plugins.xml.expected
@@ -3,7 +3,7 @@
     <pyqgis_plugin name="QGIS Plugin CI Testing" version="0.1.2">
         <about><![CDATA[Downloading would be useless]]></about>
         <author_name><![CDATA[Denis Rouzaud]]></author_name>
-        <create_date>1985-07-21</create_date>
+        <create_date>1985-07-21T00:00:00+02:00</create_date>
         <deprecated>False</deprecated>
         <description><![CDATA[This is a testing plugin for QGIS Plugin CI]]></description>
         <download_url>https://github.com/opengisch/qgis-plugin-ci/releases/download/0.1.2/qgis_plugin_CI_testing.0.1.2.zip</download_url>


### PR DESCRIPTION
- create_date is not anymore a naive date but a full timezoned datetime as in the official QGIS plugins repository
- add a new `timezone` option to make it configurable by end-user
- add related documentation
- update impacted uni tests

## Result

If `create_date` is defined as `create_date: 1985-07-21` in `.qgispluginci`, the output is:

```xml
[...]
<create_date>1985-07-21T00:00:00+00:00</create_date>
[...]
```

If `timezone: Europe/Paris` is also configured:

```xml
[...]
<create_date>1985-07-21T00:00:00+02:00</create_date>
[...]
```

If `create_date` is not configured but timezone is the same as above, the build datetime is render as timezoned:


```xml
[...]
<create_date>2026-04-22T00:00:00+02:00</create_date>
[...]
```


Related to #377

----

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->