### PR TITLE
update(tooling): switch from nose2 to pytest with coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
         env:
           tx_api_token: ${{ secrets.TRANSIFEX_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        run: nose2 -v
+        run: pytest

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -21,7 +21,7 @@ export transifex_token={CHANGE_WITH_A_REAL_TRANSIFEX_TOKEN}
 Run all tests:
 
 ```bash
-nose2 -v
+pytest
 ```
 
 Run a specific test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ dev = [
     "pre-commit>=4.5,<5",
     "ruff>=0.15.11,<0.16",
     # testing: TODO: move into a separate test section
-    "nose2>=0.15.1,<0.17"
-    ]
+    "pytest-cov>=7.1.0,<8",
+]
 
 doc = [
     "furo>=2024",
@@ -71,12 +71,40 @@ documentation = "https://opengisch.github.io/qgis-plugin-ci/"
 repository = "https://github.com/opengisch/qgis-plugin-ci/"
 tracker = "https://github.com/opengisch/qgis-plugin-ci/issues"
 
-[tool.nose2.unittest]
-start-dir = "test"
-code-directories = [".."]
+# -- TOOLING --
+[tool.coverage.report]
+exclude_lines = [
+    "if self.debug:",
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+ignore_errors = true
+show_missing = true
 
-[tool.nose2.log-capture]
-always-on = true
+[tool.coverage.run]
+branch = true
+include = ["qgispluginci/*"]
+omit = [".venv/*", "*tests*"]
+
+[tool.pytest.ini_options]
+addopts = """
+    --junitxml=junit/test-results.xml
+    --cov-append test/
+    --cov-config=pyproject.toml
+    --cov=qgispluginci
+    --cov-report=html
+    --cov-report=term
+    --cov-report=xml
+    --ignore=test/_wip/
+"""
+junit_family = "xunit2"
+log_cli = true
+log_cli_level = "DEBUG"
+minversion = "5.0"
+norecursedirs = ".* build dev development dist docs CVS fixtures _darcs {arch} *.egg venv _wip"
+python_files = "test_*.py"
+testpaths = ["test"]
 
 [tool.ruff]
 exclude = ["qgis_plugin_CI_testing/**"]

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -16,9 +16,6 @@ from zipfile import ZipFile
 import yaml
 from github import Github, GithubException
 
-# Tests
-from utils import can_skip_test_github, can_skip_test_transifex
-
 # Project
 from qgispluginci.changelog import ChangelogParser
 from qgispluginci.exceptions import GithubReleaseNotFound
@@ -26,6 +23,9 @@ from qgispluginci.parameters import DASH_WARNING, Parameters
 from qgispluginci.release import release
 from qgispluginci.translation import Translation
 from qgispluginci.utils import replace_in_file
+
+# Tests
+from test.utils import can_skip_test_github, can_skip_test_transifex
 
 
 # If changed, also update CHANGELOG.md

--- a/test/test_translation.py
+++ b/test/test_translation.py
@@ -20,6 +20,7 @@ from .utils import can_skip_test_transifex
 logger = logging.getLogger(__name__)
 
 # Ensuring proper ordering for tests sensitive to state
+# Note: no effect under pytest (which preserves declaration order natively)
 unittest.TestLoader.sortTestMethodsUsing = None
 
 


### PR DESCRIPTION
pytest looks like the de-facto standard Python testing framework and I find it more configurable and with prettier output. well I guess I'm used to so not so objective here...

I've kept the same verbose default behavior with:

```toml
log_cli = true
log_cli_level = "DEBUG"
```

But I would be in favor of defaulting to "normal" logs (.i.e not streamed and at warning level) since it's possible to change it  punctually.

----

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->