### PR TITLE
give details when TX resource fetching is failing

### DIFF
--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -93,10 +93,29 @@ class TransifexClient(BaseClient):
         logger.info(f"Resource created: {self.config.resource_slug}")
 
     def get_resource(self):
-        resources = self.get_project().fetch("resources")
+        project = self.get_project()
+        if project is None:
+            raise DoesNotExist(
+                f"Transifex project '{self.config.project_slug}' not found "
+                f"in organization '{self.config.organization_name}'. "
+                f"Check the project slug and that the API token has access to it."
+            )
+        resources = project.fetch("resources")
         if not resources:
             return None
-        return resources.get(slug=self.config.resource_slug)
+        try:
+            return resources.get(slug=self.config.resource_slug)
+        except DoesNotExist as e:
+            available = []
+            try:
+                available = [r.slug for r in resources.all()]
+            except Exception:
+                pass
+            raise DoesNotExist(
+                f"Transifex resource '{self.config.resource_slug}' not found "
+                f"in project '{self.config.organization_name}/{self.config.project_slug}'. "
+                f"Available resources: {available or 'none'}."
+            ) from e
 
     def list_resources(self):
         if resources := self.get_project().fetch("resources"):

--- a/qgispluginci/translation_clients/transifex.py
+++ b/qgispluginci/translation_clients/transifex.py
@@ -109,8 +109,13 @@ class TransifexClient(BaseClient):
             available = []
             try:
                 available = [r.slug for r in resources.all()]
-            except Exception:
-                pass
+            except Exception as list_err:
+                logger.debug(
+                    "Failed to enumerate available Transifex resources for project '%s/%s': %s",
+                    self.config.organization_name,
+                    self.config.project_slug,
+                    list_err,
+                )
             raise DoesNotExist(
                 f"Transifex resource '{self.config.resource_slug}' not found "
                 f"in project '{self.config.organization_name}/{self.config.project_slug}'. "


### PR DESCRIPTION
<!-- Thanks for your contribution to this project! Please make sure you read the following guidelines before opening a pull request. -->

## Description

give more details when TX resource fetching is failing
## Author's checklist

- [x] I have read the [contributing guidelines](https://github.com/opengisch/qgis-plugin-ci?tab=contributing-ov-file#readme) and my pull request follows them.
- [x] my commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [x] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md). Use of AI tools *must* be indicated. Failure to be honest might result in banning.

## Reviewer's checklist

- [ ] I remember to check the "Author's checklist" above and ask the author to update the PR description if any of the items are not checked.
- [ ] I remember that welcoming new contributors is more important than nitpicking on code style. I will be kind and respectful in my review comments.
